### PR TITLE
feat(dashboard): sync filters and pagination to URL query params

### DIFF
--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -1,23 +1,40 @@
 import { Pecha } from "@/components/ui/shadimport";
 import { DashboardContentTable } from "@/components/routes/dashboard/DashboardContentTable";
 import {
-  DASHBOARD_PAGE_SIZE,
   fetchDashboardItems,
   type DashboardTab,
 } from "@/components/routes/dashboard/dashboardApi";
 import type { DashboardRowKind } from "@/components/routes/dashboard/dashboardTable";
+import {
+  buildDashboardSearchParams,
+  dashboardUrlStateToFetchParams,
+  mergeDashboardUrlState,
+  parseDashboardSearchParams,
+  type DashboardPlanStatus,
+  type DashboardSort,
+  type DashboardUrlState,
+} from "@/components/routes/dashboard/dashboardUrlState";
 import { IoMdAdd, IoMdSearch } from "react-icons/io";
-import { useState, Activity, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  Activity,
+  type ReactNode,
+} from "react";
 import { useDebounce } from "use-debounce";
 import { useTranslate } from "@tolgee/react";
 import { Button } from "@/components/ui/atoms/button";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { ROUTES } from "@/routes/paths";
 import { Pagination } from "@/components/ui/molecules/pagination/Pagination";
 import AuthButton from "@/components/ui/molecules/auth-button/AuthButton";
 import { toast } from "sonner";
+
+const SEARCH_DEBOUNCE_MS = 500;
 
 const toggleFeatured = async ({
   id,
@@ -66,20 +83,44 @@ function DashboardListPlaceholder({
 
 const Dashboard = () => {
   const { t } = useTranslate();
-  const [view, setView] = useState<DashboardTab>("all");
-  const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
-  const [debouncedSearch] = useDebounce(search, 500);
-  const [sortBy, setSortBy] = useState("");
-  const [languageFilter, setLanguageFilter] = useState("");
-  const [statusFilter, setStatusFilter] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const setViewAndReset = (next: DashboardTab) => {
-    setView(next);
-    setPage(1);
-    setLanguageFilter("");
-    setStatusFilter("");
-  };
+  const urlState = useMemo(
+    () => parseDashboardSearchParams(searchParams),
+    [searchParams],
+  );
+
+  const [searchDraft, setSearchDraft] = useState(urlState.search ?? "");
+  const [debouncedSearchDraft] = useDebounce(searchDraft, SEARCH_DEBOUNCE_MS);
+
+  useEffect(() => {
+    setSearchDraft(urlState.search ?? "");
+  }, [urlState.search]);
+
+  const replaceUrlState = useCallback(
+    (patch: Partial<DashboardUrlState>) => {
+      const next = mergeDashboardUrlState(urlState, patch);
+      setSearchParams(buildDashboardSearchParams(next), { replace: true });
+    },
+    [urlState, setSearchParams],
+  );
+
+  const resetPageFilters = { page: 1 as const };
+
+  useEffect(() => {
+    const trimmed = debouncedSearchDraft.trim();
+    const committed = urlState.search ?? "";
+    if (trimmed === committed) return;
+    replaceUrlState({
+      search: trimmed || null,
+      ...resetPageFilters,
+    });
+  }, [debouncedSearchDraft, urlState.search, replaceUrlState]);
+
+  const fetchParams = useMemo(
+    () => dashboardUrlStateToFetchParams(urlState),
+    [urlState],
+  );
 
   const {
     data: dashboardData,
@@ -88,27 +129,20 @@ const Dashboard = () => {
     error,
     isError,
   } = useQuery({
-    queryKey: [
-      "dashboard-items",
-      view,
-      page,
-      debouncedSearch,
-      languageFilter,
-      statusFilter,
-      sortBy,
-    ],
-    queryFn: () =>
-      fetchDashboardItems({
-        tab: view,
-        page,
-        pageSize: DASHBOARD_PAGE_SIZE,
-        search: debouncedSearch,
-        ...(languageFilter && { language: languageFilter }),
-        ...(statusFilter && { status: statusFilter }),
-      }),
+    queryKey: ["dashboard-items", fetchParams],
+    queryFn: () => fetchDashboardItems(fetchParams),
     refetchOnWindowFocus: false,
     retry: false,
   });
+
+  const totalPages = dashboardData?.pagination.total_pages ?? 1;
+
+  useEffect(() => {
+    if (status !== "success") return;
+    if (urlState.page > totalPages && totalPages > 0) {
+      replaceUrlState({ page: totalPages });
+    }
+  }, [status, urlState.page, totalPages, replaceUrlState]);
 
   const queryClient = useQueryClient();
   const featuredMutation = useMutation({
@@ -132,8 +166,11 @@ const Dashboard = () => {
     featuredMutation.mutate({ id, kind, featured });
   };
 
+  const setTab = (next: DashboardTab) => {
+    replaceUrlState({ tab: next, ...resetPageFilters });
+  };
+
   const rows = dashboardData?.rows ?? [];
-  const totalPages = dashboardData?.pagination.total_pages ?? 1;
   const hasRows = rows.length > 0;
   const isLoadingTable = status === "pending" || isFetching;
   const showEmpty = status === "success" && !hasRows;
@@ -146,28 +183,36 @@ const Dashboard = () => {
     }`;
 
   const emptyTitle =
-    view === "plans"
+    urlState.tab === "plans"
       ? t("studio.dashboard.no_plan_found")
-      : view === "series"
+      : urlState.tab === "series"
         ? "No series found."
         : "Nothing to show yet";
 
   const emptyDescription =
-    view === "plans"
+    urlState.tab === "plans"
       ? "Create a plan to see it listed here."
-      : view === "series"
+      : urlState.tab === "series"
         ? "Create a series to see it listed here."
         : "Try clearing search or add new plans and series.";
+
+  const sortValue: DashboardSort = urlState.sort ?? "recent";
 
   const filterBar = (
     <div className="flex w-full flex-wrap items-end gap-4 px-4 pb-2 pt-3">
       <div className="flex min-w-[180px] flex-col gap-1">
         <span className="text-xs font-medium text-muted-foreground">Sort</span>
-        <Pecha.Select defaultValue="recent">
+        <Pecha.Select
+          value={sortValue}
+          onValueChange={() => {
+            // Backend sort is fixed; keep URL clean (omit `sort` = default).
+            replaceUrlState({ sort: null });
+          }}
+        >
           <Pecha.SelectTrigger className="h-9 w-[200px] bg-white dark:bg-input/30">
             <Pecha.SelectValue placeholder="Sort" />
           </Pecha.SelectTrigger>
-          <Pecha.SelectContent onClick={() => setSortBy("recent")}>
+          <Pecha.SelectContent>
             <Pecha.SelectItem value="recent">
               Recently modified
             </Pecha.SelectItem>
@@ -179,10 +224,12 @@ const Dashboard = () => {
           Language
         </span>
         <Pecha.Select
-          value={languageFilter || "all"}
+          value={urlState.language || "all"}
           onValueChange={(v) => {
-            setLanguageFilter(v === "all" ? "" : v);
-            setPage(1);
+            replaceUrlState({
+              language: v === "all" ? null : v,
+              ...resetPageFilters,
+            });
           }}
         >
           <Pecha.SelectTrigger className="h-9 w-[180px] bg-white dark:bg-input/30">
@@ -201,10 +248,12 @@ const Dashboard = () => {
           Status
         </span>
         <Pecha.Select
-          value={statusFilter || "all"}
+          value={urlState.status || "all"}
           onValueChange={(v) => {
-            setStatusFilter(v === "all" ? "" : v);
-            setPage(1);
+            replaceUrlState({
+              status: v === "all" ? null : (v as DashboardPlanStatus),
+              ...resetPageFilters,
+            });
           }}
         >
           <Pecha.SelectTrigger className="h-9 w-[200px] bg-white dark:bg-input/30">
@@ -231,11 +280,8 @@ const Dashboard = () => {
             <Pecha.Input
               placeholder={t("common.placeholder.search")}
               className="rounded-md border-none dark:bg-transparent px-4 shadow-none py-2"
-              value={search}
-              onChange={(e) => {
-                setSearch(e.target.value);
-                setPage(1);
-              }}
+              value={searchDraft}
+              onChange={(e) => setSearchDraft(e.target.value)}
             />
           </div>
 
@@ -267,22 +313,22 @@ const Dashboard = () => {
           <div className="flex flex-wrap items-center gap-2 pl-1">
             <button
               type="button"
-              className={chipClass(view === "all")}
-              onClick={() => setViewAndReset("all")}
+              className={chipClass(urlState.tab === "all")}
+              onClick={() => setTab("all")}
             >
               All
             </button>
             <button
               type="button"
-              className={chipClass(view === "plans")}
-              onClick={() => setViewAndReset("plans")}
+              className={chipClass(urlState.tab === "plans")}
+              onClick={() => setTab("plans")}
             >
               Plans
             </button>
             <button
               type="button"
-              className={chipClass(view === "series")}
-              onClick={() => setViewAndReset("series")}
+              className={chipClass(urlState.tab === "series")}
+              onClick={() => setTab("series")}
             >
               Series
             </button>
@@ -329,9 +375,9 @@ const Dashboard = () => {
 
       <Activity mode={hasRows ? "visible" : "hidden"}>
         <Pagination
-          currentPage={page}
+          currentPage={urlState.page}
           totalPages={totalPages}
-          onPageChange={setPage}
+          onPageChange={(nextPage) => replaceUrlState({ page: nextPage })}
         />
       </Activity>
     </div>

--- a/src/components/routes/dashboard/dashboardUrlState.ts
+++ b/src/components/routes/dashboard/dashboardUrlState.ts
@@ -1,0 +1,154 @@
+import type { DashboardTab } from "./dashboardApi";
+import { DASHBOARD_PAGE_SIZE } from "./dashboardApi";
+import type { FetchDashboardItemsParams } from "./dashboardApi";
+
+export type DashboardPlanStatus =
+  | "DRAFT"
+  | "PUBLISHED"
+  | "UNPUBLISHED"
+  | "ARCHIVED"
+  | "DELETED";
+
+/** UI-only until backend supports dashboard sort query params. */
+export type DashboardSort = "recent";
+
+export interface DashboardUrlState {
+  tab: DashboardTab;
+  page: number;
+  pageSize: number;
+  search: string | null;
+  status: DashboardPlanStatus | null;
+  language: string | null;
+  featured: boolean | null;
+  sort: DashboardSort | null;
+}
+
+export const DASHBOARD_URL_DEFAULTS: DashboardUrlState = {
+  tab: "all",
+  page: 1,
+  pageSize: DASHBOARD_PAGE_SIZE,
+  search: null,
+  status: null,
+  language: null,
+  featured: null,
+  sort: null,
+};
+
+const VALID_TABS = new Set<DashboardTab>(["all", "series", "plans"]);
+
+const VALID_STATUS = new Set<DashboardPlanStatus>([
+  "DRAFT",
+  "PUBLISHED",
+  "UNPUBLISHED",
+  "ARCHIVED",
+  "DELETED",
+]);
+
+const VALID_LANGUAGE = new Set(["EN", "BO", "ZH"]);
+
+const VALID_SORT = new Set<DashboardSort>(["recent"]);
+
+function parseTab(raw: string | null): DashboardTab {
+  if (raw && VALID_TABS.has(raw as DashboardTab)) {
+    return raw as DashboardTab;
+  }
+  return DASHBOARD_URL_DEFAULTS.tab;
+}
+
+function parseStatus(raw: string | null): DashboardPlanStatus | null {
+  if (!raw) return null;
+  const u = raw.trim().toUpperCase();
+  return VALID_STATUS.has(u as DashboardPlanStatus)
+    ? (u as DashboardPlanStatus)
+    : null;
+}
+
+function parseLanguage(raw: string | null): string | null {
+  if (!raw) return null;
+  const u = raw.trim().toUpperCase();
+  return VALID_LANGUAGE.has(u) ? u : null;
+}
+
+function parseSort(raw: string | null): DashboardSort | null {
+  if (!raw) return null;
+  return VALID_SORT.has(raw as DashboardSort) ? (raw as DashboardSort) : null;
+}
+
+function parsePositiveInt(
+  raw: string | null,
+  fallback: number,
+  min: number,
+  max?: number,
+): number {
+  const n = Number(raw ?? fallback);
+  if (!Number.isFinite(n)) return fallback;
+  const clamped = Math.max(min, Math.floor(n));
+  if (max != null) return Math.min(max, clamped);
+  return clamped;
+}
+
+export function parseDashboardSearchParams(
+  params: URLSearchParams,
+): DashboardUrlState {
+  const featuredRaw = params.get("featured");
+  const featured =
+    featuredRaw === "true" ? true : featuredRaw === "false" ? false : null;
+
+  const search = params.get("search")?.trim() || null;
+
+  return {
+    tab: parseTab(params.get("tab")),
+    page: parsePositiveInt(params.get("page"), DASHBOARD_URL_DEFAULTS.page, 1),
+    pageSize: parsePositiveInt(
+      params.get("page_size"),
+      DASHBOARD_URL_DEFAULTS.pageSize,
+      1,
+      100,
+    ),
+    search,
+    status: parseStatus(params.get("status")),
+    language: parseLanguage(params.get("language")),
+    featured,
+    sort: parseSort(params.get("sort")),
+  };
+}
+
+export function buildDashboardSearchParams(
+  state: DashboardUrlState,
+): URLSearchParams {
+  const p = new URLSearchParams();
+  const d = DASHBOARD_URL_DEFAULTS;
+
+  if (state.tab !== d.tab) p.set("tab", state.tab);
+  if (state.page !== d.page) p.set("page", String(state.page));
+  if (state.pageSize !== d.pageSize) p.set("page_size", String(state.pageSize));
+  if (state.search) p.set("search", state.search);
+  if (state.status) p.set("status", state.status);
+  if (state.language) p.set("language", state.language);
+  if (state.featured !== null) p.set("featured", String(state.featured));
+  if (state.sort) p.set("sort", state.sort);
+
+  return p;
+}
+
+export function dashboardUrlStateToFetchParams(
+  state: DashboardUrlState,
+): FetchDashboardItemsParams {
+  return {
+    tab: state.tab,
+    page: state.page,
+    pageSize: state.pageSize,
+    ...(state.search && { search: state.search }),
+    ...(state.status && { status: state.status }),
+    ...(state.language && { language: state.language }),
+    ...(state.featured != null && { featured: state.featured }),
+  };
+}
+
+/** Merge partial state; pass `page: 1` when filters change. */
+export function mergeDashboardUrlState(
+  current: DashboardUrlState,
+  patch: Partial<DashboardUrlState>,
+): DashboardUrlState {
+  return { ...current, ...patch };
+}


### PR DESCRIPTION
- drive tab, search, language, status, page, and page size from the URL
- add helpers to parse, serialize, and map dashboard URL state to API params
- debounce search input before committing search to the URL
- reset page when filters change and clamp page when results shrink