### PR TITLE
feat(create-plan): pre-fill series and language from series details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ dist-ssr
 coverage
 
 .cursor
-.github

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 coverage
 
 .cursor
+.github

--- a/src/components/routes/create-plan/CreatePlan.test.tsx
+++ b/src/components/routes/create-plan/CreatePlan.test.tsx
@@ -4,8 +4,14 @@ import {
   screen,
   waitFor,
   act,
+  within,
 } from "@testing-library/react";
-import { MemoryRouter, useBlocker, useParams } from "react-router-dom";
+import {
+  MemoryRouter,
+  useBlocker,
+  useLocation,
+  useParams,
+} from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import CreatePlan from "./CreatePlan";
 import { vi } from "vitest";
@@ -21,10 +27,20 @@ vi.mock("react-router-dom", async () => {
       reset: vi.fn(),
     })),
     useParams: vi.fn(() => ({})),
+    useLocation: vi.fn(() => ({
+      pathname: "/plan/new",
+      search: "",
+      hash: "",
+      state: null,
+      key: "default",
+    })),
   };
 });
 
-const renderWithProviders = (component: React.ReactElement) => {
+const renderWithProviders = (
+  component: React.ReactElement,
+  initialEntry: string | { pathname: string; state?: unknown } = "/plan/new",
+) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -33,7 +49,7 @@ const renderWithProviders = (component: React.ReactElement) => {
   });
 
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <QueryClientProvider client={queryClient}>
         {component}
       </QueryClientProvider>
@@ -66,6 +82,13 @@ describe("CreatePlan Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useParams).mockReturnValue({});
+    vi.mocked(useLocation).mockReturnValue({
+      pathname: "/plan/new",
+      search: "",
+      hash: "",
+      state: null,
+      key: "default",
+    });
     vi.spyOn(axiosInstance, "post").mockImplementation((url: string) => {
       if (url.includes("/media/upload")) {
         return Promise.resolve({
@@ -588,6 +611,103 @@ describe("CreatePlan Component", () => {
         "/api/v1/cms/plans/plan-123",
         expect.objectContaining({ start_date: null }),
       );
+    });
+  });
+
+  describe("create plan from series details", () => {
+    beforeEach(() => {
+      vi.spyOn(axiosInstance, "get").mockImplementation((url: string) => {
+        if (url.includes("/api/v1/cms/series")) {
+          return Promise.resolve({
+            data: {
+              series: [
+                {
+                  id: "series-1",
+                  metadata: [{ title: "Abhidhamma in a year", language: "EN" }],
+                },
+              ],
+            },
+          });
+        }
+        if (url.includes("/cms/tags")) {
+          return Promise.resolve({
+            data: {
+              tags: [],
+              skip: 0,
+              limit: 500,
+              total: 0,
+            },
+          });
+        }
+        return Promise.resolve({ data: {} });
+      });
+    });
+
+    it("pre-fills and locks series and language when location state is valid", async () => {
+      vi.mocked(useLocation).mockReturnValue({
+        pathname: "/plan/new",
+        search: "",
+        hash: "",
+        state: { seriesId: "series-1", language: "EN" },
+        key: "default",
+      });
+
+      renderWithProviders(<CreatePlan />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("heading", {
+            name: "Add New Plan for Abhidhamma in a year (English)",
+          }),
+        ).toBeInTheDocument();
+        expect(screen.getByText("Abhidhamma in a year")).toBeInTheDocument();
+      });
+
+      const seriesField = screen
+        .getByText("Series")
+        .closest('[data-slot="form-item"]');
+      expect(seriesField).not.toBeNull();
+      expect(
+        within(seriesField as HTMLElement).getByRole("combobox", {
+          hidden: true,
+        }),
+      ).toBeDisabled();
+
+      const languageField = screen
+        .getByText("studio.plan.form_field.language")
+        .closest('[data-slot="form-item"]');
+      expect(languageField).not.toBeNull();
+      const languageSelect = within(languageField as HTMLElement).getByRole(
+        "combobox",
+        { hidden: true },
+      );
+      expect(languageSelect).toBeDisabled();
+      expect(languageSelect).toHaveTextContent("English");
+    });
+
+    it("falls back to normal form when series id is not in the list", async () => {
+      vi.mocked(useLocation).mockReturnValue({
+        pathname: "/plan/new",
+        search: "",
+        hash: "",
+        state: { seriesId: "missing-series", language: "EN" },
+        key: "default",
+      });
+
+      renderWithProviders(<CreatePlan />);
+
+      await waitFor(() => {
+        const seriesField = screen
+          .getByText("Series")
+          .closest('[data-slot="form-item"]');
+        expect(seriesField).not.toBeNull();
+        const seriesCombobox = within(seriesField as HTMLElement).getByRole(
+          "combobox",
+          { hidden: true },
+        );
+        expect(seriesCombobox).toHaveTextContent("None");
+        expect(seriesCombobox).not.toBeDisabled();
+      });
     });
   });
 });

--- a/src/components/routes/create-plan/CreatePlan.tsx
+++ b/src/components/routes/create-plan/CreatePlan.tsx
@@ -9,7 +9,13 @@ import {
 import { useState, useRef, useEffect, useMemo } from "react";
 import { format } from "date-fns";
 import { Textarea } from "@/components/ui/atoms/textarea";
-import { useBlocker, useNavigate, useParams } from "react-router-dom";
+import {
+  useBlocker,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
+import { parsePlanNewFromSeriesState } from "./planNewFromSeriesState";
 import { ROUTES } from "@/routes/paths";
 import { planSchema } from "@/schema/PlanSchema";
 import { z } from "zod";
@@ -19,9 +25,12 @@ import {
   planTagsToIds,
   type PlanTagSummary,
 } from "@/components/routes/tags/api/tagsApi";
-import { fetchSeriesList } from "@/components/routes/create-series/api/seriesApi";
+import {
+  fetchSeriesList,
+  type SeriesOption,
+} from "@/components/routes/create-series/api/seriesApi";
 import { DIFFICULTY, PLAN_LANGUAGE } from "@/lib/constant";
-import { toBackendISO, fromBackendISO, isPastDate } from "@/lib/utils";
+import { cn, toBackendISO, fromBackendISO, isPastDate } from "@/lib/utils";
 import axiosInstance from "@/config/axios-config";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -59,6 +68,8 @@ export const postPlan = async (formdata: z.infer<typeof planSchema>) => {
   return data;
 };
 
+const EMPTY_SERIES_OPTIONS: SeriesOption[] = [];
+
 const Createplan = () => {
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
@@ -72,8 +83,13 @@ const Createplan = () => {
 
   const [isDateOpen, setIsDateOpen] = useState(false);
   const { planId } = useParams<{ planId?: string }>();
+  const location = useLocation();
   const isCreateMode = !planId;
   const { t } = useTranslate();
+  const planNewFromSeries = useMemo(
+    () => (isCreateMode ? parsePlanNewFromSeriesState(location.state) : null),
+    [isCreateMode, location.state],
+  );
   type PlanFormData = z.infer<typeof planSchema>;
   const navigate = useNavigate();
   const form = useForm({
@@ -99,7 +115,7 @@ const Createplan = () => {
   });
 
   const {
-    data: seriesOptions = [],
+    data: seriesOptionsData,
     isLoading: isSeriesLoading,
     isError: isSeriesError,
   } = useQuery({
@@ -107,6 +123,7 @@ const Createplan = () => {
     queryFn: fetchSeriesList,
     refetchOnWindowFocus: false,
   });
+  const seriesOptions = seriesOptionsData ?? EMPTY_SERIES_OPTIONS;
 
   useEffect(() => {
     if (isSeriesError) {
@@ -125,6 +142,67 @@ const Createplan = () => {
     if (!q) return seriesOptions;
     return seriesOptions.filter((s) => s.title.toLowerCase().includes(q));
   }, [seriesOptions, seriesQuery]);
+
+  const lockSeriesAndLanguageFields = useMemo(() => {
+    if (!planNewFromSeries) return false;
+    if (isSeriesLoading) return true;
+    if (isSeriesError) return false;
+    return seriesOptions.some((s) => s.id === planNewFromSeries.seriesId);
+  }, [planNewFromSeries, isSeriesLoading, isSeriesError, seriesOptions]);
+
+  const pageHeading = useMemo(() => {
+    if (!isCreateMode) return "Plan Edit";
+    if (!planNewFromSeries) return "Plan Details";
+    if (lockSeriesAndLanguageFields) {
+      const seriesTitle = seriesOptions.find(
+        (s) => s.id === planNewFromSeries.seriesId,
+      )?.title;
+      const languageLabel = PLAN_LANGUAGE.find(
+        (l) => l.value === planNewFromSeries.language,
+      )?.label;
+      if (seriesTitle && languageLabel) {
+        return `Add New Plan for ${seriesTitle} (${languageLabel})`;
+      }
+      if (seriesTitle) return `Add New Plan for ${seriesTitle}`;
+    }
+    if (isSeriesLoading) return "Add New Plan";
+    return "Plan Details";
+  }, [
+    isCreateMode,
+    planNewFromSeries,
+    lockSeriesAndLanguageFields,
+    seriesOptions,
+    isSeriesLoading,
+  ]);
+
+  useEffect(() => {
+    if (!isCreateMode || !planNewFromSeries) return;
+
+    if (isSeriesLoading) {
+      form.setValue("series_id", planNewFromSeries.seriesId);
+      form.setValue("language", planNewFromSeries.language);
+      return;
+    }
+
+    const seriesExists = seriesOptions.some(
+      (s) => s.id === planNewFromSeries.seriesId,
+    );
+
+    if (!isSeriesError && seriesExists) {
+      form.setValue("series_id", planNewFromSeries.seriesId);
+      form.setValue("language", planNewFromSeries.language);
+      return;
+    }
+
+    form.setValue("series_id", null);
+    form.setValue("language", "");
+  }, [
+    isCreateMode,
+    planNewFromSeries,
+    isSeriesLoading,
+    isSeriesError,
+    seriesOptions,
+  ]);
 
   useEffect(() => {
     if (planId && planData) {
@@ -262,9 +340,7 @@ const Createplan = () => {
   return (
     <div className="flex flex-col sm:flex-row border h-[calc(100vh-40px)] overflow-auto bg-[#F5F5F5] dark:bg-[#181818] my-4 rounded-l-2xl font-dynamic">
       <div className="flex-1 p-4 sm:p-10">
-        <h1 className="text-xl font-bold my-4">
-          Plan {isCreateMode ? "Details" : "Edit"}
-        </h1>
+        <h1 className="text-xl font-bold my-4">{pageHeading}</h1>
 
         <Pecha.Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -592,41 +668,53 @@ const Createplan = () => {
                   seriesTriggerLabel = selectedSeries?.title ?? "None";
                 }
 
+                const isSeriesFieldDisabled =
+                  lockSeriesAndLanguageFields ||
+                  isSeriesLoading ||
+                  isSeriesError;
+
                 return (
                   <Pecha.FormItem className="flex flex-col">
                     <Pecha.FormLabel className="text-sm font-bold">
                       Series
                     </Pecha.FormLabel>
                     <Pecha.Popover
-                      open={isSeriesOpen}
+                      open={isSeriesFieldDisabled ? false : isSeriesOpen}
                       onOpenChange={(open) => {
+                        if (isSeriesFieldDisabled) return;
                         setIsSeriesOpen(open);
                         if (!open) setSeriesQuery("");
                       }}
                     >
-                      <Pecha.PopoverTrigger asChild>
-                        <Pecha.FormControl>
-                          <Pecha.Button
-                            type="button"
-                            variant="outline"
-                            role="combobox"
-                            aria-expanded={isSeriesOpen}
-                            disabled={isSeriesLoading || isSeriesError}
-                            className="h-12 w-full justify-between rounded-md bg-white px-3 font-normal"
-                          >
-                            <span
-                              className={
-                                selectedSeries
-                                  ? "text-foreground"
-                                  : "text-muted-foreground"
-                              }
+                      <div
+                        className={cn(
+                          isSeriesFieldDisabled && "cursor-not-allowed",
+                        )}
+                      >
+                        <Pecha.PopoverTrigger asChild>
+                          <Pecha.FormControl>
+                            <Pecha.Button
+                              type="button"
+                              variant="outline"
+                              role="combobox"
+                              aria-expanded={isSeriesOpen}
+                              disabled={isSeriesFieldDisabled}
+                              className="h-12 w-full justify-between rounded-md bg-white px-3 font-normal"
                             >
-                              {seriesTriggerLabel}
-                            </span>
-                            <IoChevronDown className="size-4 opacity-50" />
-                          </Pecha.Button>
-                        </Pecha.FormControl>
-                      </Pecha.PopoverTrigger>
+                              <span
+                                className={
+                                  selectedSeries
+                                    ? "text-foreground"
+                                    : "text-muted-foreground"
+                                }
+                              >
+                                {seriesTriggerLabel}
+                              </span>
+                              <IoChevronDown className="size-4 opacity-50" />
+                            </Pecha.Button>
+                          </Pecha.FormControl>
+                        </Pecha.PopoverTrigger>
+                      </div>
                       <Pecha.PopoverContent
                         className="w-[--radix-popover-trigger-width] p-0"
                         align="start"
@@ -734,9 +822,13 @@ const Createplan = () => {
                     <Pecha.Select
                       onValueChange={field.onChange}
                       value={field.value}
+                      disabled={lockSeriesAndLanguageFields}
                     >
                       <Pecha.FormControl>
-                        <Pecha.SelectTrigger className="h-12 w-full bg-white">
+                        <Pecha.SelectTrigger
+                          className="h-12 w-full bg-white"
+                          disabled={lockSeriesAndLanguageFields}
+                        >
                           <Pecha.SelectValue
                             placeholder={t(
                               "studio.plan.form.placeholder.select_language",

--- a/src/components/routes/create-plan/planNewFromSeriesState.test.ts
+++ b/src/components/routes/create-plan/planNewFromSeriesState.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { parsePlanNewFromSeriesState } from "./planNewFromSeriesState";
+
+describe("parsePlanNewFromSeriesState", () => {
+  it("returns null for missing or partial state", () => {
+    expect(parsePlanNewFromSeriesState(null)).toBeNull();
+    expect(parsePlanNewFromSeriesState({ seriesId: "s1" })).toBeNull();
+    expect(parsePlanNewFromSeriesState({ language: "EN" })).toBeNull();
+  });
+
+  it("returns parsed state when seriesId and language are valid", () => {
+    expect(
+      parsePlanNewFromSeriesState({ seriesId: "series-1", language: "BO" }),
+    ).toEqual({ seriesId: "series-1", language: "BO" });
+  });
+
+  it("rejects invalid language codes", () => {
+    expect(
+      parsePlanNewFromSeriesState({ seriesId: "series-1", language: "FR" }),
+    ).toBeNull();
+  });
+});

--- a/src/components/routes/create-plan/planNewFromSeriesState.ts
+++ b/src/components/routes/create-plan/planNewFromSeriesState.ts
@@ -1,0 +1,31 @@
+import { PLAN_LANGUAGE } from "@/lib/constant";
+import type { LanguageCode } from "@/schema/SeriesSchema";
+
+export type PlanNewFromSeriesState = {
+  seriesId: string;
+  language: LanguageCode;
+};
+
+const VALID_LANGUAGE_CODES = new Set(
+  PLAN_LANGUAGE.map((l) => l.value as LanguageCode),
+);
+
+export function parsePlanNewFromSeriesState(
+  state: unknown,
+): PlanNewFromSeriesState | null {
+  if (!state || typeof state !== "object") return null;
+
+  const { seriesId, language } = state as Record<string, unknown>;
+  if (typeof seriesId !== "string" || !seriesId.trim()) return null;
+  if (
+    typeof language !== "string" ||
+    !VALID_LANGUAGE_CODES.has(language as LanguageCode)
+  ) {
+    return null;
+  }
+
+  return {
+    seriesId: seriesId.trim(),
+    language: language as LanguageCode,
+  };
+}

--- a/src/components/routes/series-details/SeriesDetailsPage.test.tsx
+++ b/src/components/routes/series-details/SeriesDetailsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { vi } from "vitest";
 import SeriesDetailsPage from "./SeriesDetailsPage";
@@ -63,6 +63,47 @@ describe("SeriesDetailsPage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("navigates to plan new with series and active language in location state", async () => {
+    function PlanNewStateProbe() {
+      const { state } = useLocation();
+      return (
+        <div data-testid="plan-new-location-state">{JSON.stringify(state)}</div>
+      );
+    }
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/series/series-1"]}>
+          <Routes>
+            <Route path="/series/:seriesId" element={<SeriesDetailsPage />} />
+            <Route path="/plan/new" element={<PlanNewStateProbe />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Abhidhamma in a year")).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /中文/i }));
+    await user.click(screen.getByRole("link", { name: /Add New Plan/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("plan-new-location-state")).toHaveTextContent(
+        JSON.stringify({ seriesId: "series-1", language: "ZH" }),
+      );
+    });
   });
 
   it("renders series title and plans for selected language tab", async () => {

--- a/src/components/routes/series-details/SeriesDetailsPage.tsx
+++ b/src/components/routes/series-details/SeriesDetailsPage.tsx
@@ -222,13 +222,16 @@ const SeriesDetailsPage = () => {
             activePlans.length > 0 ? "py-8" : "py-16"
           }`}
         >
-          <Link to={ROUTES.planNew}>
+          <Link
+            to={ROUTES.planNew}
+            state={{ seriesId: seriesId!, language: activeLanguage }}
+          >
             <Pecha.Button
               type="button"
               className="gap-2 bg-[#A51C21] hover:bg-[#8a171c] text-white"
             >
               <IoMdAdd className="h-4 w-4" />
-              Add plan
+              Add New Plan
             </Pecha.Button>
           </Link>
         </div>


### PR DESCRIPTION
- Renamed **Add plan** → **Add New Plan** on `/series/:seriesId`
- **Add New Plan** goes to `/plan/new` with `location.state`: `seriesId` + active language tab (EN / BO / ZH)
- Create plan form **pre-fills** series and language from that state
- Series and language fields are **disabled** when context is valid (same flow as locked from series)
- **Page title** changes (e.g. `Add New Plan for {series} (English)`) instead of plain “Plan Details”
- **Not-allowed cursor** on disabled series field (wrapper fix)
- **Fallback:** no state, refresh, or bad/missing series → normal create form (“Plan Details”, fields editable)
- After save → still opens **plan detail** (`/plan/{id}`)
- Tests: series navigation, form pre-fill/lock, state parser