### PR TITLE
feat(dashboard): enhance localization support for dashboard item titles

### DIFF
--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -24,7 +24,7 @@ import {
   type ReactNode,
 } from "react";
 import { useDebounce } from "use-debounce";
-import { useTranslate } from "@tolgee/react";
+import { useTolgee, useTranslate } from "@tolgee/react";
 import { Button } from "@/components/ui/atoms/button";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
@@ -83,6 +83,8 @@ function DashboardListPlaceholder({
 
 const Dashboard = () => {
   const { t } = useTranslate();
+  const tolgee = useTolgee(["language"]);
+  const localeLanguage = tolgee.getLanguage();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const urlState = useMemo(
@@ -118,8 +120,11 @@ const Dashboard = () => {
   }, [debouncedSearchDraft, urlState.search, replaceUrlState]);
 
   const fetchParams = useMemo(
-    () => dashboardUrlStateToFetchParams(urlState),
-    [urlState],
+    () => ({
+      ...dashboardUrlStateToFetchParams(urlState),
+      localeLanguage,
+    }),
+    [urlState, localeLanguage],
   );
 
   const {
@@ -340,12 +345,13 @@ const Dashboard = () => {
       {filterBar}
 
       <div className="flex flex-1 flex-col items-center px-4 pb-6 pt-2">
-        {isError && error ? (
+        {isError && error && (
           <DashboardListPlaceholder
             title="Unable to load dashboard"
             description={String(error.message)}
           />
-        ) : showEmpty ? (
+        )}
+        {showEmpty && (
           <DashboardListPlaceholder
             title={emptyTitle}
             description={emptyDescription}
@@ -361,7 +367,8 @@ const Dashboard = () => {
               </Pecha.Button>
             </Link>
           </DashboardListPlaceholder>
-        ) : (
+        )}
+        {!isError && !showEmpty && (
           <div className="w-full overflow-x-auto">
             <DashboardContentTable
               rows={rows}

--- a/src/components/routes/dashboard/DashboardContentTable.tsx
+++ b/src/components/routes/dashboard/DashboardContentTable.tsx
@@ -46,7 +46,6 @@ export function DashboardContentTable({
         row.kind === "series" ||
         (row.kind === "plan" && !isMockDashboardId(row.id));
       const featuredDisabled = row.status !== "PUBLISHED";
-
       return (
         <Pecha.TableRow
           key={`${row.kind}-${row.id}`}

--- a/src/components/routes/dashboard/dashboardApi.test.ts
+++ b/src/components/routes/dashboard/dashboardApi.test.ts
@@ -22,7 +22,37 @@ describe("displayDashboardItemTitle", () => {
     expect(displayDashboardItemTitle(item)).toBe("7-Day Mindfulness");
   });
 
-  it("uses EN metadata title for series (no top-level title)", () => {
+  it("uses metadata title for the current UI locale", () => {
+    const item: DashboardApiItem = {
+      id: "s1",
+      type: "series",
+      metadata: [
+        {
+          id: "m1",
+          title: "Foundations of Meditation",
+          description: "Intro",
+          language: "EN",
+        },
+        {
+          id: "m2",
+          title: "བོད་སྐད་",
+          language: "BO",
+        },
+      ],
+      status: "DRAFT",
+      featured: true,
+      languages: ["EN", "BO"],
+      enrolled_count: 12,
+      plans_count: 3,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    expect(displayDashboardItemTitle(item, "bo-IN")).toBe("བོད་སྐད་");
+    expect(displayDashboardItemTitle(item, "en")).toBe(
+      "Foundations of Meditation",
+    );
+  });
+
+  it("uses EN metadata title for series when locale is omitted", () => {
     const item: DashboardApiItem = {
       id: "s1",
       type: "series",
@@ -47,6 +77,24 @@ describe("displayDashboardItemTitle", () => {
       created_at: "2026-01-01T00:00:00Z",
     };
     expect(displayDashboardItemTitle(item)).toBe("Foundations of Meditation");
+  });
+
+  it("falls back to the first metadata title when locale title is missing", () => {
+    const item: DashboardApiItem = {
+      id: "s1",
+      type: "series",
+      metadata: [
+        { id: "m1", title: "", language: "BO" },
+        { id: "m2", title: "Only ZH title", language: "ZH" },
+        { id: "m3", title: "English backup", language: "EN" },
+      ],
+      status: "DRAFT",
+      featured: false,
+      languages: ["BO", "ZH", "EN"],
+      enrolled_count: 0,
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    expect(displayDashboardItemTitle(item, "bo-IN")).toBe("Only ZH title");
   });
 
   it("falls back when series has no metadata", () => {

--- a/src/components/routes/dashboard/dashboardApi.ts
+++ b/src/components/routes/dashboard/dashboardApi.ts
@@ -3,23 +3,35 @@ import {
   normalizeStatus,
   parseDashboardLanguages,
   pickSeriesTitle,
+  tolgeeLocaleToDashboardLanguage,
   type DashboardTableRow,
 } from "./dashboardTable";
 
 /** Series rows omit `title` in JSON; titles live in `metadata`. */
-export function displayDashboardItemTitle(item: DashboardApiItem): string {
+export function displayDashboardItemTitle(
+  item: DashboardApiItem,
+  localeLanguage?: string,
+): string {
   if (item.type === "plan") {
     return item.title?.trim() || "Untitled plan";
   }
-  const fromMeta = pickSeriesTitle(undefined, item.metadata);
+  const preferredLanguage = tolgeeLocaleToDashboardLanguage(localeLanguage);
+  const fromMeta = pickSeriesTitle(
+    undefined,
+    item.metadata,
+    preferredLanguage ?? undefined,
+  );
   return fromMeta === "Untitled" ? "Untitled series" : fromMeta;
 }
 
-function mapDashboardItemToTableRow(item: DashboardApiItem): DashboardTableRow {
+function mapDashboardItemToTableRow(
+  item: DashboardApiItem,
+  localeLanguage?: string,
+): DashboardTableRow {
   return {
     kind: item.type,
     id: String(item.id),
-    title: displayDashboardItemTitle(item),
+    title: displayDashboardItemTitle(item, localeLanguage),
     image_url: item.image_url ?? "",
     languages: parseDashboardLanguages(item.languages),
     status: normalizeStatus(item.status),
@@ -81,6 +93,8 @@ export interface FetchDashboardItemsParams {
   status?: string;
   language?: string;
   featured?: boolean;
+  /** Tolgee UI locale used to pick localized series titles from metadata. */
+  localeLanguage?: string;
 }
 
 export interface DashboardItemsResult {
@@ -111,7 +125,6 @@ export async function fetchDashboardItems(
       },
     },
   );
-
   const items = data?.items ?? [];
   const pagination = data?.pagination ?? {
     page: params.page,
@@ -119,9 +132,11 @@ export async function fetchDashboardItems(
     total: items.length,
     total_pages: items.length > 0 ? 1 : 0,
   };
-
+  
   return {
-    rows: items.map(mapDashboardItemToTableRow),
+    rows: items.map((item) =>
+      mapDashboardItemToTableRow(item, params.localeLanguage),
+    ),
     pagination,
   };
 }

--- a/src/components/routes/dashboard/dashboardTable.ts
+++ b/src/components/routes/dashboard/dashboardTable.ts
@@ -56,23 +56,58 @@ function titleFromMetadataRow(row: Record<string, unknown>): string {
   return typeof title === "string" && title.trim() ? title.trim() : "";
 }
 
+const DEFAULT_LANG_ORDER: DashboardLanguageCode[] = ["EN", "BO", "ZH"];
+
+/** Map Tolgee UI locale (e.g. `en`, `bo-IN`) to dashboard metadata language codes. */
+export function tolgeeLocaleToDashboardLanguage(
+  locale: string | undefined | null,
+): DashboardLanguageCode | null {
+  const l = (locale ?? "").trim().toLowerCase();
+  if (!l) return null;
+  if (l.startsWith("en")) return "EN";
+  if (l.startsWith("bo")) return "BO";
+  if (l.startsWith("zh")) return "ZH";
+  return null;
+}
+
+function firstTitleFromMetadataRows(rows: Record<string, unknown>[]): string {
+  for (const row of rows) {
+    const t = titleFromMetadataRow(row);
+    if (t) return t;
+  }
+  return "";
+}
+
+function titleForMetadataLanguage(
+  rows: Record<string, unknown>[],
+  language: DashboardLanguageCode,
+): string {
+  const row = rows.find(
+    (r) => String(r.language ?? r.lang ?? "").toUpperCase() === language,
+  );
+  return row ? titleFromMetadataRow(row) : "";
+}
+
 export function pickSeriesTitle(
   nameOrTitle: unknown,
   metadata?: unknown,
+  preferredLanguage?: DashboardLanguageCode,
 ): string {
   if (Array.isArray(metadata) && metadata.length > 0) {
     const rows = metadata as Record<string, unknown>[];
-    const order = ["EN", "BO", "ZH"];
-    for (const lang of order) {
-      const row = rows.find(
-        (r) => String(r.language ?? r.lang ?? "").toUpperCase() === lang,
-      );
-      const t = row ? titleFromMetadataRow(row) : "";
-      if (t) return t;
-    }
-    for (const row of rows) {
-      const t = titleFromMetadataRow(row);
-      if (t) return t;
+
+    if (preferredLanguage) {
+      const preferredTitle = titleForMetadataLanguage(rows, preferredLanguage);
+      if (preferredTitle) return preferredTitle;
+      const fallback = firstTitleFromMetadataRows(rows);
+      if (fallback) return fallback;
+    } else {
+      for (const lang of DEFAULT_LANG_ORDER) {
+        const t = titleForMetadataLanguage(rows, lang);
+        if (t) return t;
+      }
+      const fallback = firstTitleFromMetadataRows(rows);
+      if (fallback) return fallback;
     }
   }
   if (!nameOrTitle) return "Untitled";


### PR DESCRIPTION
- integrated Tolgee for improved language handling in dashboard components
- updated displayDashboardItemTitle to accept localeLanguage for localized titles
- modified mapDashboardItemToTableRow to utilize localeLanguage
- added tests to verify title selection based on current UI locale
- streamlined metadata title selection logic for better fallback handling