### PR TITLE
Platform RBAC, content transfers, and reviewer-safe CMS

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,12 @@ export default tseslint.config([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
+    },
   },
 ]);

--- a/src/components/auth/PlanRouteGuard.test.tsx
+++ b/src/components/auth/PlanRouteGuard.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import PlanRouteGuard from "./PlanRouteGuard";
+import { ROUTES } from "@/routes/paths";
+
+vi.mock("@/hooks/useUserInfo", () => ({
+  useUserInfo: vi.fn(),
+}));
+
+import { useUserInfo } from "@/hooks/useUserInfo";
+
+describe("PlanRouteGuard", () => {
+  it("redirects reviewers to dashboard", () => {
+    vi.mocked(useUserInfo).mockReturnValue({
+      data: { id: "1", platform_role: "REVIEWER" },
+      isLoading: false,
+    } as ReturnType<typeof useUserInfo>);
+
+    render(
+      <MemoryRouter initialEntries={["/plan/plan-1"]}>
+        <Routes>
+          <Route
+            path="/plan/:planId"
+            element={
+              <PlanRouteGuard>
+                <div>Plan page</div>
+              </PlanRouteGuard>
+            }
+          />
+          <Route path={ROUTES.dashboard} element={<div>Dashboard</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("Plan page")).not.toBeInTheDocument();
+  });
+
+  it("renders children for creators", () => {
+    vi.mocked(useUserInfo).mockReturnValue({
+      data: { id: "1", platform_role: "CREATOR" },
+      isLoading: false,
+    } as ReturnType<typeof useUserInfo>);
+
+    render(
+      <MemoryRouter initialEntries={["/plan/plan-1"]}>
+        <Routes>
+          <Route
+            path="/plan/:planId"
+            element={
+              <PlanRouteGuard>
+                <div>Plan page</div>
+              </PlanRouteGuard>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Plan page")).toBeInTheDocument();
+  });
+});

--- a/src/components/auth/PlanRouteGuard.tsx
+++ b/src/components/auth/PlanRouteGuard.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { canAccessPlanRoutes } from "@/lib/platformAccess";
+import { ROUTES } from "@/routes/paths";
+
+type PlanRouteGuardProps = {
+  children: ReactNode;
+};
+
+/** Blocks `/plan/*` CMS routes for platform REVIEWER (read-only staff). */
+const PlanRouteGuard = ({ children }: PlanRouteGuardProps) => {
+  const { data: userInfo, isLoading } = useUserInfo();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[calc(100vh-40px)] items-center justify-center text-muted-foreground">
+        Loading…
+      </div>
+    );
+  }
+
+  if (userInfo && !canAccessPlanRoutes(userInfo.platform_role)) {
+    return <Navigate to={ROUTES.dashboard} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PlanRouteGuard;

--- a/src/components/auth/ProtectedRoute.test.tsx
+++ b/src/components/auth/ProtectedRoute.test.tsx
@@ -4,9 +4,14 @@ import { vi } from "vitest";
 import ProtectedRoute from "./ProtectedRoute";
 
 const mockUseAuth = vi.fn();
+const mockUseUserInfo = vi.fn();
 
 vi.mock("@/config/auth-context", () => ({
   useAuth: () => mockUseAuth(),
+}));
+
+vi.mock("@/hooks/useUserInfo", () => ({
+  useUserInfo: () => mockUseUserInfo(),
 }));
 
 const mockNavigate = vi.fn();
@@ -28,6 +33,15 @@ const renderWithRouter = (component: React.ReactElement) => {
 describe("ProtectedRoute Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseUserInfo.mockReturnValue({
+      data: {
+        is_verified: true,
+        is_active: true,
+        has_group: true,
+        platform_role: "CREATOR",
+      },
+      isLoading: false,
+    });
   });
 
   it("displays loading state when authentication is loading", () => {
@@ -58,20 +72,15 @@ describe("ProtectedRoute Component", () => {
       </ProtectedRoute>,
     );
 
-    expect(screen.getByTestId("navigate")).toBeDefined();
     expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/login");
-    expect(screen.getByTestId("navigate")).toHaveAttribute(
-      "data-replace",
-      "true",
-    );
-    expect(screen.queryByText("Protected Content")).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith("/login", true);
   });
 
-  it("renders children when user is authenticated and not loading", () => {
+  it("renders children when user is authenticated and onboarding complete", () => {
     mockUseAuth.mockReturnValue({
       isLoggedIn: true,
       isAuthLoading: false,
+      logout: vi.fn(),
     });
 
     renderWithRouter(
@@ -81,40 +90,45 @@ describe("ProtectedRoute Component", () => {
     );
 
     expect(screen.getByText("Protected Content")).toBeDefined();
-    expect(screen.queryByText("common.loading")).toBeNull();
-    expect(screen.queryByTestId("navigate")).toBeNull();
-    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("renders complex children components when authenticated", () => {
+  it("redirects inactive users to login", () => {
     mockUseAuth.mockReturnValue({
       isLoggedIn: true,
       isAuthLoading: false,
+      logout: vi.fn(),
     });
-
-    const ComplexChild = () => (
-      <div>
-        <h1>Dashboard</h1>
-        <button>Action Button</button>
-        <p>Some content here</p>
-      </div>
-    );
+    mockUseUserInfo.mockReturnValue({
+      data: {
+        is_verified: true,
+        is_active: false,
+        has_group: true,
+      },
+      isLoading: false,
+    });
 
     renderWithRouter(
       <ProtectedRoute>
-        <ComplexChild />
+        <div>Protected Content</div>
       </ProtectedRoute>,
     );
 
-    expect(screen.getByText("Dashboard")).toBeDefined();
-    expect(screen.getByText("Action Button")).toBeDefined();
-    expect(screen.getByText("Some content here")).toBeDefined();
+    expect(screen.getByTestId("navigate")).toHaveAttribute("data-to", "/login");
   });
 
-  it("does not render children during loading state even if user appears logged in", () => {
+  it("redirects to groups when user has no group", () => {
     mockUseAuth.mockReturnValue({
       isLoggedIn: true,
-      isAuthLoading: true,
+      isAuthLoading: false,
+      logout: vi.fn(),
+    });
+    mockUseUserInfo.mockReturnValue({
+      data: {
+        is_verified: true,
+        is_active: true,
+        has_group: false,
+      },
+      isLoading: false,
     });
 
     renderWithRouter(
@@ -123,29 +137,9 @@ describe("ProtectedRoute Component", () => {
       </ProtectedRoute>,
     );
 
-    expect(screen.getByText("common.loading")).toBeDefined();
-    expect(screen.queryByText("Protected Content")).toBeNull();
-  });
-
-  it("uses the correct CSS classes for loading state", () => {
-    mockUseAuth.mockReturnValue({
-      isLoggedIn: false,
-      isAuthLoading: true,
-    });
-
-    renderWithRouter(
-      <ProtectedRoute>
-        <div>Protected Content</div>
-      </ProtectedRoute>,
+    expect(screen.getByTestId("navigate")).toHaveAttribute(
+      "data-to",
+      "/groups",
     );
-
-    const loadingContainer = screen.getByText("common.loading").parentElement;
-    expect(loadingContainer).toHaveClass(
-      "flex",
-      "items-center",
-      "justify-center",
-      "h-full",
-    );
-    expect(screen.getByText("common.loading")).toHaveClass("text-lg");
   });
 });

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,14 +1,35 @@
+import { useEffect } from "react";
 import { useAuth } from "@/config/auth-context";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useTranslate } from "@tolgee/react";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import {
+  needsGroupOnboardingRedirect,
+  needsInactiveLogout,
+  needsVerifyEmailRedirect,
+} from "@/lib/platformAccess";
+import { ROUTES } from "@/routes/paths";
+
 interface ProtectedRouteProps {
   children: React.ReactNode;
 }
 
 const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
-  const { isLoggedIn, isAuthLoading } = useAuth();
+  const { isLoggedIn, isAuthLoading, logout } = useAuth();
   const { t } = useTranslate();
-  if (isAuthLoading) {
+  const location = useLocation();
+  const { data: userInfo, isLoading: isUserInfoLoading } = useUserInfo({
+    enabled: isLoggedIn,
+  });
+
+  useEffect(() => {
+    if (!isLoggedIn || isUserInfoLoading || !userInfo) return;
+    if (needsInactiveLogout(userInfo)) {
+      logout();
+    }
+  }, [isLoggedIn, isUserInfoLoading, userInfo, logout]);
+
+  if (isAuthLoading || (isLoggedIn && isUserInfoLoading)) {
     return (
       <div className="flex items-center justify-center h-full">
         <div className="text-lg">{t("common.loading")}</div>
@@ -17,7 +38,33 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   }
 
   if (!isLoggedIn) {
-    return <Navigate to="/login" replace />;
+    const inactive =
+      (location.state as { inactive?: boolean } | null)?.inactive === true;
+    return (
+      <Navigate
+        to={ROUTES.login}
+        replace
+        state={inactive ? { inactive: true } : undefined}
+      />
+    );
+  }
+
+  if (userInfo && needsInactiveLogout(userInfo)) {
+    return (
+      <Navigate
+        to={ROUTES.login}
+        replace
+        state={{ inactive: true, message: "Author not active" }}
+      />
+    );
+  }
+
+  if (userInfo && needsVerifyEmailRedirect(userInfo)) {
+    return <Navigate to={ROUTES.verifyEmail} replace />;
+  }
+
+  if (userInfo && needsGroupOnboardingRedirect(location.pathname, userInfo)) {
+    return <Navigate to={ROUTES.groups} replace />;
   }
 
   return <>{children}</>;

--- a/src/components/auth/login/Login.tsx
+++ b/src/components/auth/login/Login.tsx
@@ -2,25 +2,46 @@ import { Button } from "@/components/ui/atoms/button";
 import { Input } from "@/components/ui/atoms/input";
 import { Label } from "@/components/ui/atoms/label";
 import ContainerLayout from "@/components/ui/atoms/studio-card";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuth } from "@/config/auth-context";
 import { useTranslate } from "@tolgee/react";
 import { createPasswordHash } from "@/lib/utils";
+import {
+  AUTHOR_NOT_ACTIVE_DETAIL,
+  isAuthorNotActiveDetail,
+} from "@/lib/platformAccess";
+import { getApiErrorDetail } from "@/lib/apiErrors";
+import { ROUTES } from "@/routes/paths";
+
 interface LoginData {
   email: string;
   password: string;
 }
+
 const Login = () => {
   const { t } = useTranslate();
   const navigate = useNavigate();
+  const location = useLocation();
   const [email, setEmail] = useState("");
   const [errors, setErrors] = useState<string>("");
   const [successMessage, setSuccessMessage] = useState<string>("");
   const [showEmailReverify, setShowEmailReverify] = useState<boolean>(false);
+  const [inactiveOnly, setInactiveOnly] = useState(false);
   const { login } = useAuth();
+
+  useEffect(() => {
+    const state = location.state as {
+      inactive?: boolean;
+      message?: string;
+    } | null;
+    if (state?.inactive) {
+      setInactiveOnly(true);
+      setErrors(state.message ?? AUTHOR_NOT_ACTIVE_DETAIL);
+    }
+  }, [location.state]);
 
   const loginMutation = useMutation<any, Error, LoginData>({
     mutationFn: async (loginData: LoginData) => {
@@ -34,17 +55,24 @@ const Login = () => {
       const accessToken = data.auth.access_token;
       const refreshToken = data.auth.refresh_token;
       login(accessToken, refreshToken);
-      navigate("/dashboard");
+      navigate(ROUTES.dashboard);
     },
     onError: (error: any) => {
-      const errorMsg = error?.response?.data?.detail || "Login failed";
-
-      const emailVerificationErrorMessage = errorMsg
+      const detail = getApiErrorDetail(error) ?? "Login failed";
+      const emailVerificationErrorMessage = detail
         .toLowerCase()
         .includes("author not verified");
 
+      if (isAuthorNotActiveDetail(detail)) {
+        setInactiveOnly(true);
+        setShowEmailReverify(false);
+        setErrors(AUTHOR_NOT_ACTIVE_DETAIL);
+        return;
+      }
+
+      setInactiveOnly(false);
       setShowEmailReverify(emailVerificationErrorMessage);
-      setErrors(errorMsg || "");
+      setErrors(detail);
     },
   });
 
@@ -62,8 +90,8 @@ const Login = () => {
     },
     onError: (error: any) => {
       const errorMsg =
-        error?.response?.data?.detail || "Email re-verification failed";
-      setErrors(errorMsg || "");
+        getApiErrorDetail(error) || "Email re-verification failed";
+      setErrors(errorMsg);
       setSuccessMessage("");
     },
   });
@@ -72,6 +100,7 @@ const Login = () => {
     e.preventDefault();
     setShowEmailReverify(false);
     setSuccessMessage("");
+    setInactiveOnly(false);
     const formData = new FormData(e.currentTarget);
     const password = formData.get("password") as string;
     const clientPassword = createPasswordHash(email, password);
@@ -86,6 +115,22 @@ const Login = () => {
     setSuccessMessage("");
     emailReverifyMutation.mutate({ email });
   };
+
+  if (inactiveOnly) {
+    return (
+      <ContainerLayout title={t("studio.login.title")}>
+        <div className="w-full max-w-[425px] space-y-4 text-center">
+          <p className="text-sm text-muted-foreground">
+            {errors || AUTHOR_NOT_ACTIVE_DETAIL}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Your account must be activated by a platform administrator before
+            you can sign in.
+          </p>
+        </div>
+      </ContainerLayout>
+    );
+  }
 
   return (
     <ContainerLayout title={t("studio.login.title")}>

--- a/src/components/routes/admin-authors/AdminAuthorsPage.tsx
+++ b/src/components/routes/admin-authors/AdminAuthorsPage.tsx
@@ -1,0 +1,245 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Pecha } from "@/components/ui/shadimport";
+import { Button } from "@/components/ui/atoms/button";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import { useUserInfo, USER_INFO_QUERY_KEY } from "@/hooks/useUserInfo";
+import {
+  canAccessAdminAuthors,
+  isSuperAdmin,
+  type PlatformRole,
+} from "@/lib/platformAccess";
+import { Navigate } from "react-router-dom";
+import { ROUTES } from "@/routes/paths";
+import {
+  activateAuthor,
+  fetchAdminAuthors,
+  patchAuthorPlatformRole,
+  suspendAuthor,
+  type AdminAuthorDTO,
+} from "./api/adminAuthorsApi";
+
+const PAGE_SIZE = 20;
+
+const AdminAuthorsPage = () => {
+  const { data: userInfo } = useUserInfo();
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [activationQueue, setActivationQueue] = useState(true);
+
+  const canAccess = Boolean(
+    userInfo && canAccessAdminAuthors(userInfo.platform_role),
+  );
+  const writeEnabled = isSuperAdmin(userInfo?.platform_role);
+  const showActionsColumn = writeEnabled;
+  const tableColumnCount = showActionsColumn ? 6 : 5;
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["admin-authors", page, activationQueue],
+    queryFn: () =>
+      fetchAdminAuthors({
+        skip: page * PAGE_SIZE,
+        limit: PAGE_SIZE,
+        ...(activationQueue ? { is_verified: true, is_active: false } : {}),
+      }),
+    enabled: canAccess,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["admin-authors"] });
+    queryClient.invalidateQueries({ queryKey: USER_INFO_QUERY_KEY });
+  };
+
+  const activateMutation = useMutation({
+    mutationFn: activateAuthor,
+    onSuccess: () => {
+      toast.success("Author activated");
+      invalidate();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const suspendMutation = useMutation({
+    mutationFn: suspendAuthor,
+    onSuccess: () => {
+      toast.success("Author suspended");
+      invalidate();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const roleMutation = useMutation({
+    mutationFn: ({ id, role }: { id: string; role: PlatformRole }) =>
+      patchAuthorPlatformRole(id, role),
+    onSuccess: () => {
+      toast.success("Platform role updated");
+      invalidate();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const authors = data?.authors ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  const displayName = (a: AdminAuthorDTO) =>
+    [a.firstname, a.lastname].filter(Boolean).join(" ").trim() || a.email;
+
+  if (userInfo && !canAccess) {
+    return <Navigate to={ROUTES.dashboard} replace />;
+  }
+
+  return (
+    <div className="font-dynamic border h-[calc(100vh-40px)] overflow-auto bg-[#F5F5F5] dark:bg-[#181818] my-4 rounded-l-2xl">
+      <div className="px-4 pt-10 pb-4 flex flex-wrap items-center justify-between gap-3">
+        <h1 className="text-xl font-semibold">Authors</h1>
+        <div className="flex gap-2">
+          <Button
+            variant={activationQueue ? "default" : "outline"}
+            size="sm"
+            onClick={() => {
+              setActivationQueue(true);
+              setPage(0);
+            }}
+          >
+            Activation queue
+          </Button>
+          <Button
+            variant={!activationQueue ? "default" : "outline"}
+            size="sm"
+            onClick={() => {
+              setActivationQueue(false);
+              setPage(0);
+            }}
+          >
+            All authors
+          </Button>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="px-4 text-destructive text-sm">
+          {getApiErrorMessage(error)}
+        </p>
+      ) : null}
+
+      <div className="px-4 pb-8 overflow-x-auto">
+        <Pecha.Table>
+          <Pecha.TableHeader>
+            <Pecha.TableRow>
+              <Pecha.TableHead>Name</Pecha.TableHead>
+              <Pecha.TableHead>Email</Pecha.TableHead>
+              <Pecha.TableHead>Role</Pecha.TableHead>
+              <Pecha.TableHead>Verified</Pecha.TableHead>
+              <Pecha.TableHead>Active</Pecha.TableHead>
+              {showActionsColumn ? (
+                <Pecha.TableHead>Actions</Pecha.TableHead>
+              ) : null}
+            </Pecha.TableRow>
+          </Pecha.TableHeader>
+          <Pecha.TableBody>
+            {isLoading ? (
+              <Pecha.TableRow>
+                <Pecha.TableCell colSpan={tableColumnCount}>
+                  Loading…
+                </Pecha.TableCell>
+              </Pecha.TableRow>
+            ) : authors.length === 0 ? (
+              <Pecha.TableRow>
+                <Pecha.TableCell colSpan={tableColumnCount}>
+                  No authors found.
+                </Pecha.TableCell>
+              </Pecha.TableRow>
+            ) : (
+              authors.map((author) => (
+                <Pecha.TableRow key={author.id}>
+                  <Pecha.TableCell>{displayName(author)}</Pecha.TableCell>
+                  <Pecha.TableCell>{author.email}</Pecha.TableCell>
+                  <Pecha.TableCell>
+                    {writeEnabled ? (
+                      <select
+                        className="rounded border bg-background px-2 py-1 text-sm"
+                        value={author.platform_role}
+                        onChange={(e) =>
+                          roleMutation.mutate({
+                            id: author.id,
+                            role: e.target.value as PlatformRole,
+                          })
+                        }
+                        disabled={roleMutation.isPending}
+                      >
+                        <option value="CREATOR">CREATOR</option>
+                        <option value="REVIEWER">REVIEWER</option>
+                        <option value="SUPER_ADMIN">SUPER_ADMIN</option>
+                      </select>
+                    ) : (
+                      author.platform_role
+                    )}
+                  </Pecha.TableCell>
+                  <Pecha.TableCell>
+                    {author.is_verified ? "Yes" : "No"}
+                  </Pecha.TableCell>
+                  <Pecha.TableCell>
+                    {author.is_active ? "Yes" : "No"}
+                  </Pecha.TableCell>
+                  {showActionsColumn ? (
+                    <Pecha.TableCell>
+                      <div className="flex gap-2">
+                        {!author.is_active ? (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={activateMutation.isPending}
+                            onClick={() => activateMutation.mutate(author.id)}
+                          >
+                            Activate
+                          </Button>
+                        ) : (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={suspendMutation.isPending}
+                            onClick={() => suspendMutation.mutate(author.id)}
+                          >
+                            Suspend
+                          </Button>
+                        )}
+                      </div>
+                    </Pecha.TableCell>
+                  ) : null}
+                </Pecha.TableRow>
+              ))
+            )}
+          </Pecha.TableBody>
+        </Pecha.Table>
+
+        {totalPages > 1 ? (
+          <div className="mt-4 flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={page <= 0}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              Previous
+            </Button>
+            <span className="text-sm self-center">
+              Page {page + 1} of {totalPages}
+            </span>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={page + 1 >= totalPages}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default AdminAuthorsPage;

--- a/src/components/routes/admin-authors/api/adminAuthorsApi.ts
+++ b/src/components/routes/admin-authors/api/adminAuthorsApi.ts
@@ -1,0 +1,72 @@
+import axiosInstance from "@/config/axios-config";
+import type { PlatformRole } from "@/lib/platformAccess";
+
+export type AdminAuthorDTO = {
+  id: string;
+  email: string;
+  firstname?: string | null;
+  lastname?: string | null;
+  platform_role: PlatformRole;
+  is_verified: boolean;
+  is_active: boolean;
+  has_group: boolean;
+  created_at?: string;
+};
+
+export type AdminAuthorsListResponse = {
+  authors: AdminAuthorDTO[];
+  skip: number;
+  limit: number;
+  total: number;
+};
+
+export type FetchAdminAuthorsParams = {
+  is_verified?: boolean;
+  is_active?: boolean;
+  search?: string;
+  skip?: number;
+  limit?: number;
+};
+
+export const fetchAdminAuthors = async (
+  params: FetchAdminAuthorsParams = {},
+): Promise<AdminAuthorsListResponse> => {
+  const { data } = await axiosInstance.get<AdminAuthorsListResponse>(
+    `/api/v1/cms/admin/authors`,
+    {
+      params: {
+        skip: params.skip ?? 0,
+        limit: params.limit ?? 20,
+        ...(params.is_verified != null && { is_verified: params.is_verified }),
+        ...(params.is_active != null && { is_active: params.is_active }),
+        ...(params.search?.trim() && { search: params.search.trim() }),
+      },
+    },
+  );
+  return data;
+};
+
+export const activateAuthor = async (authorId: string) => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/admin/authors/${authorId}/activate`,
+  );
+  return data;
+};
+
+export const suspendAuthor = async (authorId: string) => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/admin/authors/${authorId}/suspend`,
+  );
+  return data;
+};
+
+export const patchAuthorPlatformRole = async (
+  authorId: string,
+  platform_role: PlatformRole,
+) => {
+  const { data } = await axiosInstance.patch(
+    `/api/v1/cms/admin/authors/${authorId}/platform-role`,
+    { platform_role },
+  );
+  return data;
+};

--- a/src/components/routes/content-transfer/api/transferApi.test.ts
+++ b/src/components/routes/content-transfer/api/transferApi.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterIncomingForGroup,
+  idsEqual,
+  normalizeTransferListResponse,
+  normalizeTransferRequest,
+} from "./transferApi";
+
+describe("transferApi normalization", () => {
+  it("parses CMS incoming transfers payload", () => {
+    const payload = {
+      transfers: [
+        {
+          id: "971fff46-27c2-4edb-8c7b-5e2d2c0820dc",
+          entity_type: "plan",
+          entity_id: "4ed427a3-a9cc-4db3-a612-77b4b906c106",
+          from_group_id: "c9e9f7f6-1dfd-4649-8b9e-8d9d22fe7951",
+          to_group_id: "583ccaf1-ffe4-47af-8907-132ea7a5f4b3",
+          status: "PENDING",
+          entity_title: "sc",
+          from_group_title: "G2",
+          to_group_title: "G3",
+          expires_at: "2026-06-04T11:27:57.654533Z",
+          created_at: "2026-06-04T10:47:35.106483Z",
+        },
+      ],
+      total: 1,
+    };
+    const { requests } = normalizeTransferListResponse(payload);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.content_type).toBe("plan");
+    expect(requests[0]?.target_group_id).toBe(
+      "583ccaf1-ffe4-47af-8907-132ea7a5f4b3",
+    );
+    expect(
+      filterIncomingForGroup(requests, "583ccaf1-ffe4-47af-8907-132ea7a5f4b3"),
+    ).toHaveLength(1);
+  });
+
+  it("extracts nested request arrays", () => {
+    const payload = {
+      data: {
+        requests: [
+          {
+            id: "req-1",
+            content_type: "plan",
+            content_id: "plan-1",
+            status: "PENDING",
+            source_group_id: "g-source",
+            target_group_id: "g-target",
+          },
+        ],
+      },
+    };
+    expect(normalizeTransferListResponse(payload).requests).toHaveLength(1);
+  });
+
+  it("normalizes alternate id and group field names", () => {
+    const row = normalizeTransferRequest({
+      request_id: "req-2",
+      content_type: "series",
+      series_id: "series-1",
+      status: "pending",
+      source_group: { id: "aaa-bbb" },
+      target_group: { id: "ccc-ddd" },
+      expires_at: "2099-01-01T00:00:00Z",
+    });
+    expect(row?.id).toBe("req-2");
+    expect(row?.content_type).toBe("series");
+    expect(row?.source_group_id).toBe("aaa-bbb");
+    expect(row?.target_group_id).toBe("ccc-ddd");
+    expect(row?.status).toBe("PENDING");
+  });
+
+  it("filters incoming by target group case-insensitively", () => {
+    const requests = [
+      {
+        id: "1",
+        status: "PENDING" as const,
+        content_type: "plan" as const,
+        content_id: "p1",
+        source_group_id: "a",
+        target_group_id: "ABC-DEF",
+        created_at: "",
+        expires_at: "2099-01-01T00:00:00Z",
+      },
+    ];
+    expect(
+      filterIncomingForGroup(requests, "abc-def").map((r) => r.id),
+    ).toEqual(["1"]);
+  });
+
+  it("compares ids case-insensitively", () => {
+    expect(idsEqual("ABC", "abc")).toBe(true);
+  });
+});

--- a/src/components/routes/content-transfer/api/transferApi.ts
+++ b/src/components/routes/content-transfer/api/transferApi.ts
@@ -1,0 +1,284 @@
+import axiosInstance from "@/config/axios-config";
+
+export type TransferRequestStatus =
+  | "PENDING"
+  | "ACCEPTED"
+  | "REJECTED"
+  | "REVOKED"
+  | "EXPIRED";
+
+export type ContentTransferRequestDTO = {
+  id: string;
+  status: TransferRequestStatus;
+  content_type: "plan" | "series";
+  content_id: string;
+  content_title?: string | null;
+  source_group_id: string;
+  target_group_id: string;
+  source_group_title?: string | null;
+  target_group_title?: string | null;
+  created_at: string;
+  expires_at: string;
+};
+
+export type TransferRequestListResponse = {
+  requests: ContentTransferRequestDTO[];
+};
+
+function pickGroupId(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    if (typeof id === "string" && id.trim()) return id.trim();
+  }
+  return undefined;
+}
+
+function pickString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function idsEqual(a?: string | null, b?: string | null): boolean {
+  if (!a?.trim() || !b?.trim()) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** Walk common API envelope shapes to find the request array. */
+export function extractTransferRequestArray(
+  data: unknown,
+  depth = 0,
+): unknown[] {
+  if (data == null || depth > 5) return [];
+  if (Array.isArray(data)) return data;
+
+  if (typeof data !== "object") return [];
+
+  const root = data as Record<string, unknown>;
+  const arrayKeys = [
+    "transfers",
+    "requests",
+    "items",
+    "transfer_requests",
+    "incoming",
+    "outgoing",
+    "results",
+    "data",
+  ];
+
+  for (const key of arrayKeys) {
+    const nested = extractTransferRequestArray(root[key], depth + 1);
+    if (nested.length > 0) return nested;
+  }
+
+  return [];
+}
+
+/** Normalizes list payloads when the API uses alternate keys or nested group objects. */
+export function normalizeTransferRequest(
+  raw: unknown,
+): ContentTransferRequestDTO | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+
+  const id =
+    pickString(r.id) ??
+    pickString(r.request_id) ??
+    pickString(r.transfer_request_id);
+  if (!id) return null;
+
+  const typeRaw =
+    pickString(r.entity_type) ??
+    pickString(r.content_type) ??
+    pickString(r.type);
+  const contentType = typeRaw?.toLowerCase() === "series" ? "series" : "plan";
+
+  const contentId =
+    pickString(r.entity_id) ??
+    pickString(r.content_id) ??
+    (contentType === "series"
+      ? pickString(r.series_id)
+      : pickString(r.plan_id)) ??
+    "";
+
+  const targetGroup =
+    r.to_group_id ??
+    r.target_group_id ??
+    r.target_group_uuid ??
+    r.targetGroupId ??
+    r.destination_group_id ??
+    r.target_group;
+
+  const sourceGroup =
+    r.from_group_id ??
+    r.source_group_id ??
+    r.source_group_uuid ??
+    r.sourceGroupId ??
+    r.source_group;
+
+  return {
+    id,
+    status:
+      (pickString(r.status)?.toUpperCase() as TransferRequestStatus) ??
+      "PENDING",
+    content_type: contentType,
+    content_id: contentId,
+    content_title:
+      pickString(r.entity_title) ??
+      pickString(r.content_title) ??
+      pickString(r.title) ??
+      null,
+    source_group_id: pickGroupId(sourceGroup) ?? "",
+    target_group_id: pickGroupId(targetGroup) ?? "",
+    source_group_title:
+      pickString(r.from_group_title) ??
+      pickString(r.source_group_title) ??
+      pickString((sourceGroup as { title?: string } | undefined)?.title) ??
+      null,
+    target_group_title:
+      pickString(r.to_group_title) ??
+      pickString(r.target_group_title) ??
+      pickString((targetGroup as { title?: string } | undefined)?.title) ??
+      null,
+    created_at: pickString(r.created_at) ?? new Date().toISOString(),
+    expires_at:
+      pickString(r.expires_at) ??
+      pickString(r.expiresAt) ??
+      new Date().toISOString(),
+  };
+}
+
+export function normalizeTransferListResponse(
+  data: unknown,
+): TransferRequestListResponse {
+  const list = extractTransferRequestArray(data);
+  const requests = list
+    .map(normalizeTransferRequest)
+    .filter((r): r is ContentTransferRequestDTO => r != null);
+
+  return { requests };
+}
+
+export function filterIncomingForGroup(
+  requests: ContentTransferRequestDTO[],
+  groupId: string,
+): ContentTransferRequestDTO[] {
+  const matched = requests.filter(
+    (r) => !r.target_group_id || idsEqual(r.target_group_id, groupId),
+  );
+  return matched;
+}
+
+export function filterOutgoingForGroup(
+  requests: ContentTransferRequestDTO[],
+  groupId: string,
+): ContentTransferRequestDTO[] {
+  return requests.filter(
+    (r) => !r.source_group_id || idsEqual(r.source_group_id, groupId),
+  );
+}
+
+/** Prefer global list (what notifications use); optional group query params. */
+async function fetchIncomingList(
+  groupId?: string,
+): Promise<TransferRequestListResponse> {
+  const { data } = await axiosInstance.get(
+    "/api/v1/cms/transfer-requests/incoming",
+    {
+      params: groupId
+        ? { target_group_id: groupId, group_id: groupId }
+        : undefined,
+    },
+  );
+  const normalized = normalizeTransferListResponse(data);
+
+  if (!groupId) return normalized;
+
+  const matched = filterIncomingForGroup(normalized.requests, groupId);
+  if (matched.length > 0) return { requests: matched };
+
+  // Server returned rows but group ids were missing/mismatched in JSON — show all.
+  if (normalized.requests.length > 0) return normalized;
+
+  return { requests: [] };
+}
+
+async function fetchOutgoingList(
+  groupId?: string,
+): Promise<TransferRequestListResponse> {
+  const { data } = await axiosInstance.get(
+    "/api/v1/cms/transfer-requests/outgoing",
+    {
+      params: groupId
+        ? { source_group_id: groupId, group_id: groupId }
+        : undefined,
+    },
+  );
+  const normalized = normalizeTransferListResponse(data);
+
+  if (!groupId) return normalized;
+
+  const matched = filterOutgoingForGroup(normalized.requests, groupId);
+  if (matched.length > 0) return { requests: matched };
+
+  if (normalized.requests.length > 0) return normalized;
+
+  return { requests: [] };
+}
+
+export const fetchIncomingTransferRequests = async (
+  groupId?: string,
+): Promise<TransferRequestListResponse> => fetchIncomingList(groupId);
+
+export const fetchOutgoingTransferRequests = async (
+  groupId?: string,
+): Promise<TransferRequestListResponse> => fetchOutgoingList(groupId);
+
+export const createPlanTransferRequest = async (
+  planId: string,
+  targetGroupId: string,
+): Promise<ContentTransferRequestDTO> => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/plans/${planId}/transfer-requests`,
+    { target_group_id: targetGroupId },
+  );
+  return normalizeTransferRequest(data) ?? (data as ContentTransferRequestDTO);
+};
+
+export const createSeriesTransferRequest = async (
+  seriesId: string,
+  targetGroupId: string,
+): Promise<ContentTransferRequestDTO> => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/series/${seriesId}/transfer-requests`,
+    { target_group_id: targetGroupId },
+  );
+  return normalizeTransferRequest(data) ?? (data as ContentTransferRequestDTO);
+};
+
+export const acceptTransferRequest = async (requestId: string) => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/transfer-requests/${requestId}/accept`,
+  );
+  return data;
+};
+
+export const rejectTransferRequest = async (requestId: string) => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/transfer-requests/${requestId}/reject`,
+  );
+  return data;
+};
+
+export const revokeTransferRequest = async (requestId: string) => {
+  const { data } = await axiosInstance.post(
+    `/api/v1/cms/transfer-requests/${requestId}/revoke`,
+  );
+  return data;
+};
+
+export function isTransferRequestExpired(
+  req: ContentTransferRequestDTO,
+): boolean {
+  if (req.status === "EXPIRED") return true;
+  return new Date(req.expires_at).getTime() <= Date.now();
+}

--- a/src/components/routes/content-transfer/components/ContentTransferDialog.tsx
+++ b/src/components/routes/content-transfer/components/ContentTransferDialog.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useDebounce } from "use-debounce";
+import { toast } from "sonner";
+import { Pecha } from "@/components/ui/shadimport";
+import { Button } from "@/components/ui/atoms/button";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import {
+  createPlanTransferRequest,
+  createSeriesTransferRequest,
+} from "../api/transferApi";
+import {
+  fetchGroupsForTransfer,
+  pickGroupTitle,
+  type AuthorGroupListItem,
+} from "@/components/routes/groups/api/groupsApi";
+
+type ContentTransferDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  contentType: "plan" | "series";
+  contentId: string;
+  sourceGroupId: string;
+  contentTitle?: string;
+  onSuccess?: () => void;
+};
+
+const ContentTransferDialog = ({
+  open,
+  onOpenChange,
+  contentType,
+  contentId,
+  sourceGroupId,
+  contentTitle,
+  onSuccess,
+}: ContentTransferDialogProps) => {
+  const [search, setSearch] = useState("");
+  const [debouncedSearch] = useDebounce(search, 400);
+  const [groups, setGroups] = useState<AuthorGroupListItem[]>([]);
+  const [isLoadingGroups, setIsLoadingGroups] = useState(false);
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      setSelectedGroupId(null);
+      setGroups([]);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingGroups(true);
+    void fetchGroupsForTransfer({
+      search: debouncedSearch || undefined,
+      excludeGroupId: sourceGroupId,
+    })
+      .then((list) => {
+        if (cancelled) return;
+        setGroups(list);
+      })
+      .catch(() => {
+        if (!cancelled) setGroups([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingGroups(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, debouncedSearch, sourceGroupId]);
+
+  const transferMutation = useMutation({
+    mutationFn: (targetGroupId: string) =>
+      contentType === "series"
+        ? createSeriesTransferRequest(contentId, targetGroupId)
+        : createPlanTransferRequest(contentId, targetGroupId),
+    onSuccess: () => {
+      toast.success("Transfer request sent", {
+        description: "The target group can accept or reject the request.",
+      });
+      onOpenChange(false);
+      onSuccess?.();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const entityLabel = contentType === "series" ? "series" : "plan";
+
+  return (
+    <Pecha.Dialog open={open} onOpenChange={onOpenChange}>
+      <Pecha.DialogContent className="max-w-md">
+        <Pecha.DialogHeader>
+          <Pecha.DialogTitle>Transfer {entityLabel}</Pecha.DialogTitle>
+        </Pecha.DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {contentTitle
+            ? `Send "${contentTitle}" to another group for approval.`
+            : `Choose a target group for this ${entityLabel}.`}
+        </p>
+
+        <div className="space-y-3 py-2">
+          <Pecha.Input
+            placeholder="Search groups…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+
+          <div className="max-h-52 overflow-y-auto rounded-md border border-input">
+            {isLoadingGroups ? (
+              <p className="px-3 py-4 text-sm text-muted-foreground">
+                Loading groups…
+              </p>
+            ) : groups.length === 0 ? (
+              <p className="px-3 py-4 text-sm text-muted-foreground">
+                No other groups found.
+              </p>
+            ) : (
+              <ul>
+                {groups.map((group) => {
+                  const title = pickGroupTitle(group.metadata);
+                  const selected = selectedGroupId === group.id;
+                  return (
+                    <li key={group.id}>
+                      <button
+                        type="button"
+                        className={`w-full px-3 py-2 text-left text-sm hover:bg-muted/60 ${
+                          selected ? "bg-muted font-medium" : ""
+                        }`}
+                        onClick={() => setSelectedGroupId(group.id)}
+                      >
+                        {title}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90"
+            disabled={!selectedGroupId || transferMutation.isPending}
+            onClick={() => {
+              if (selectedGroupId) {
+                transferMutation.mutate(selectedGroupId);
+              }
+            }}
+          >
+            {transferMutation.isPending ? "Sending…" : "Send request"}
+          </Button>
+        </div>
+      </Pecha.DialogContent>
+    </Pecha.Dialog>
+  );
+};
+
+export default ContentTransferDialog;

--- a/src/components/routes/create-plan/CreatePlan.test.tsx
+++ b/src/components/routes/create-plan/CreatePlan.test.tsx
@@ -26,9 +26,9 @@ vi.mock("react-router-dom", async () => {
       proceed: vi.fn(),
       reset: vi.fn(),
     })),
-    useParams: vi.fn(() => ({})),
+    useParams: vi.fn(() => ({ groupId: "test-group-id" })),
     useLocation: vi.fn(() => ({
-      pathname: "/plan/new",
+      pathname: "/groups/test-group-id/plan/new",
       search: "",
       hash: "",
       state: null,
@@ -81,9 +81,9 @@ vi.mock(
 describe("CreatePlan Component", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useParams).mockReturnValue({});
+    vi.mocked(useParams).mockReturnValue({ groupId: "test-group-id" });
     vi.mocked(useLocation).mockReturnValue({
-      pathname: "/plan/new",
+      pathname: "/groups/test-group-id/plan/new",
       search: "",
       hash: "",
       state: null,
@@ -373,7 +373,7 @@ describe("CreatePlan Component", () => {
   });
 
   it("shows validation errors for required fields", async () => {
-    vi.mocked(useParams).mockReturnValue({});
+    vi.mocked(useParams).mockReturnValue({ groupId: "test-group-id" });
     renderWithProviders(<CreatePlan />);
     const submitButton = screen.getByText("studio.plan.next_button");
     fireEvent.click(submitButton);

--- a/src/components/routes/create-plan/CreatePlan.tsx
+++ b/src/components/routes/create-plan/CreatePlan.tsx
@@ -82,7 +82,10 @@ const Createplan = () => {
   );
 
   const [isDateOpen, setIsDateOpen] = useState(false);
-  const { planId } = useParams<{ planId?: string }>();
+  const { planId, groupId } = useParams<{
+    planId?: string;
+    groupId?: string;
+  }>();
   const location = useLocation();
   const isCreateMode = !planId;
   const { t } = useTranslate();
@@ -92,6 +95,13 @@ const Createplan = () => {
   );
   type PlanFormData = z.infer<typeof planSchema>;
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (isCreateMode && !groupId) {
+      navigate(ROUTES.groups, { replace: true });
+    }
+  }, [isCreateMode, groupId, navigate]);
+
   const form = useForm({
     resolver: zodResolver(planSchema),
     defaultValues: {
@@ -239,7 +249,11 @@ const Createplan = () => {
       form.reset();
       setSelectedImage(null);
       setImagePreview(null);
-      navigate(ROUTES.plan(data.id));
+      if (groupId) {
+        navigate(ROUTES.group(groupId));
+      } else {
+        navigate(ROUTES.plan(data.id));
+      }
     },
     onError: (error) => {
       toast.error("Failed to create plan", {
@@ -327,14 +341,19 @@ const Createplan = () => {
     };
     if (planId) {
       if (isSeriesError) {
-        const { series_id, ...rest } = payload;
+        const { series_id: _seriesId, ...rest } = payload;
+        void _seriesId;
         updatePlanMutation.mutate({ plan_id: planId, formdata: rest });
       } else {
         updatePlanMutation.mutate({ plan_id: planId, formdata: payload });
       }
     } else {
       const { series_id, ...rest } = payload;
-      createPlanMutation.mutate(series_id ? { ...rest, series_id } : rest);
+      const body = {
+        ...(series_id ? { ...rest, series_id } : rest),
+        group_id: groupId!,
+      };
+      createPlanMutation.mutate(body);
     }
   };
   return (

--- a/src/components/routes/create-plan/PlanNewLegacyRedirect.tsx
+++ b/src/components/routes/create-plan/PlanNewLegacyRedirect.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { getSeries } from "@/components/routes/create-series/api/seriesApi";
+import { parsePlanNewFromSeriesState } from "./planNewFromSeriesState";
+import { ROUTES } from "@/routes/paths";
+
+/** Sends legacy `/plan/new` (with optional series state) to group-scoped create. */
+const PlanNewLegacyRedirect = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const fromSeries = parsePlanNewFromSeriesState(location.state);
+
+  useEffect(() => {
+    if (!fromSeries) {
+      navigate(ROUTES.groups, { replace: true });
+      return;
+    }
+
+    let cancelled = false;
+    void getSeries(fromSeries.seriesId)
+      .then((series) => {
+        if (cancelled) return;
+        if (series.group_id) {
+          navigate(ROUTES.groupPlanNew(series.group_id), {
+            replace: true,
+            state: location.state,
+          });
+        } else {
+          navigate(ROUTES.groups, { replace: true });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) navigate(ROUTES.groups, { replace: true });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fromSeries, location.state, navigate]);
+
+  return null;
+};
+
+export default PlanNewLegacyRedirect;

--- a/src/components/routes/create-series/CreateSeries.tsx
+++ b/src/components/routes/create-series/CreateSeries.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useBlocker, useNavigate, useParams } from "react-router-dom";
+import { ROUTES } from "@/routes/paths";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslate } from "@tolgee/react";
 import { IoMdAdd, IoMdClose } from "react-icons/io";
@@ -27,13 +28,25 @@ import {
   putUpdateSeries,
 } from "@/components/routes/create-series/api/seriesApi";
 import type { SeriesFormData } from "@/schema/SeriesSchema";
+import { useGroupContentPermissions } from "@/hooks/useGroupContentPermissions";
+import { canWriteCms } from "@/lib/platformAccess";
 
 const CreateSeries = () => {
-  const { seriesId } = useParams<{ seriesId: string }>();
+  const { seriesId, groupId } = useParams<{
+    seriesId?: string;
+    groupId?: string;
+  }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { t } = useTranslate();
   const isNew = !seriesId;
+
+  useEffect(() => {
+    if (isNew && !groupId) {
+      navigate(ROUTES.groups, { replace: true });
+    }
+  }, [isNew, groupId, navigate]);
+
   const {
     form,
     languages,
@@ -58,6 +71,26 @@ const CreateSeries = () => {
     enabled: Boolean(seriesId) && !isNew,
     refetchOnWindowFocus: false,
   });
+
+  const seriesGroupId = groupId ?? seriesData?.group_id ?? undefined;
+  const seriesStatus = isNew ? "DRAFT" : (seriesData?.status ?? "DRAFT");
+  const {
+    userInfo,
+    groupRole,
+    platformReadOnly,
+    canEdit: canEditSeries,
+  } = useGroupContentPermissions(seriesGroupId, seriesStatus);
+
+  const canSaveSeries =
+    !platformReadOnly &&
+    (isNew
+      ? Boolean(seriesGroupId) &&
+        canWriteCms(userInfo) &&
+        groupRole != null &&
+        groupRole !== "VIEWER"
+      : canEditSeries);
+
+  const formReadOnly = !canSaveSeries;
 
   const seriesHydratedIdRef = useRef<string | null>(null);
 
@@ -120,7 +153,11 @@ const CreateSeries = () => {
 
   const saveSeriesMutation = useMutation({
     mutationFn: async (input: { data: SeriesFormData; featured: boolean }) => {
-      const body = buildSeriesUpdateBody(input.data, input.featured);
+      const body = buildSeriesUpdateBody(
+        input.data,
+        input.featured,
+        isNew ? groupId : undefined,
+      );
       if (isNew) {
         const created = await postSeries(body);
         return { id: String(created.id) };
@@ -144,8 +181,12 @@ const CreateSeries = () => {
         setSelectedImage(null);
         setImagePreview(null);
         setActivePlansLanguage(null);
+        if (groupId) {
+          navigate(ROUTES.group(groupId));
+          return;
+        }
       }
-      navigate("/dashboard");
+      navigate(ROUTES.dashboard);
     },
     onError: (error: Error) => {
       toast.error(
@@ -205,6 +246,7 @@ const CreateSeries = () => {
   };
 
   const onSubmit = form.handleSubmit((data) => {
+    if (formReadOnly) return;
     const featured = isNew ? false : (seriesData?.featured ?? false);
     saveSeriesMutation.mutate({ data, featured });
   });
@@ -236,7 +278,8 @@ const CreateSeries = () => {
     imageUrl.trim().length > 0 &&
     (isNew || !!seriesData);
 
-  const saveDisabled = !submitEnabled || (!isNew && !form.formState.isDirty);
+  const saveDisabled =
+    formReadOnly || !submitEnabled || (!isNew && !form.formState.isDirty);
 
   const saveLabel = saveSeriesMutation.isPending
     ? isNew
@@ -252,6 +295,16 @@ const CreateSeries = () => {
         <h1 className="text-xl font-bold my-4 border-b border-dashed border-black dark:border-white">
           {isNew ? "Series details" : "Series Edit"}
         </h1>
+
+        {formReadOnly ? (
+          <p className="mb-4 text-sm text-muted-foreground">
+            {platformReadOnly
+              ? "You have read-only access to series in this group."
+              : isNew
+                ? "You cannot create a series in this group with your current role."
+                : "This series cannot be edited with your current role."}
+          </p>
+        ) : null}
 
         <Pecha.Form {...form}>
           <form onSubmit={onSubmit} className="space-y-6">
@@ -274,7 +327,8 @@ const CreateSeries = () => {
                     <button
                       type="button"
                       onClick={() => removeLanguage(code)}
-                      className="absolute top-2 right-2 text-muted-foreground hover:text-foreground p-1 rounded"
+                      disabled={formReadOnly}
+                      className="absolute top-2 right-2 text-muted-foreground hover:text-foreground p-1 rounded disabled:opacity-40"
                       aria-label={`Remove ${label}`}
                     >
                       <IoMdClose className="h-4 w-4" />
@@ -291,6 +345,7 @@ const CreateSeries = () => {
                             <Pecha.Input
                               placeholder={`Title in ${label}`}
                               className="h-12 text-base bg-white dark:bg-[#181818]"
+                              disabled={formReadOnly}
                               {...field}
                             />
                           </Pecha.FormControl>
@@ -311,6 +366,7 @@ const CreateSeries = () => {
                             <Textarea
                               placeholder={`Description in ${label}`}
                               className="min-h-[100px] w-full rounded-md border border-input bg-white dark:bg-[#181818] px-3 py-2 text-base placeholder:text-muted-foreground focus-visible:outline-none resize-none"
+                              disabled={formReadOnly}
                               {...field}
                             />
                           </Pecha.FormControl>
@@ -323,7 +379,7 @@ const CreateSeries = () => {
               })}
             </div>
 
-            {availableLanguages.length > 0 ? (
+            {!formReadOnly && availableLanguages.length > 0 ? (
               <Pecha.Select
                 key={addedLanguages.join(",")}
                 onValueChange={(v) => addLanguage(v as LanguageCode)}
@@ -506,7 +562,7 @@ const CreateSeries = () => {
               })}
             </div>
 
-            {activePlansLanguage != null && (
+            {!formReadOnly && activePlansLanguage != null && (
               <PlanSearchSelector
                 value={plans[activePlansLanguage] ?? []}
                 onChange={(next) => {
@@ -518,6 +574,7 @@ const CreateSeries = () => {
                   );
                 }}
                 searchLanguage={activePlansLanguage}
+                groupId={seriesGroupId}
               />
             )}
           </>

--- a/src/components/routes/create-series/api/planSearchApi.ts
+++ b/src/components/routes/create-series/api/planSearchApi.ts
@@ -23,6 +23,7 @@ export type Plan = {
   subscription_count: number;
   author: PlanAuthor;
   start_date: string | null;
+  group_id?: string | null;
 };
 
 export type SearchPlansResponse = {
@@ -38,13 +39,33 @@ export type SearchPlansParams = {
   language?: string;
   skip?: number;
   limit?: number;
+  group_id?: string;
 };
 
 export const searchPlans = async (
   params: SearchPlansParams,
 ): Promise<SearchPlansResponse> => {
-  const { data } = await axiosInstance.get("/api/v1/cms/plans", {
-    params,
+  const { group_id, ...rest } = params;
+  const { data } = await axiosInstance.get<SearchPlansResponse>(
+    "/api/v1/cms/plans",
+    {
+      params: {
+        ...rest,
+        ...(group_id ? { group_id } : {}),
+      },
+    },
+  );
+
+  if (!group_id) {
+    return data;
+  }
+
+  const plans = (data.plans ?? []).filter((plan) => {
+    if (plan.group_id != null) {
+      return plan.group_id === group_id;
+    }
+    return true;
   });
-  return data;
+
+  return { ...data, plans };
 };

--- a/src/components/routes/create-series/api/seriesApi.ts
+++ b/src/components/routes/create-series/api/seriesApi.ts
@@ -16,6 +16,7 @@ export type SeriesPayload = {
   image_key?: string;
   featured: boolean;
   plans: Partial<Record<LanguageCode, string[]>>;
+  group_id?: string;
 };
 
 export type SeriesUpdatePayload = Partial<SeriesPayload>;
@@ -51,6 +52,7 @@ export type SeriesDetailDTO = {
   image?: string | null;
   image_key?: string | null;
   author_id?: string;
+  group_id?: string | null;
   featured: boolean;
   status: string;
   plans: SeriesPlanDTO[];
@@ -239,6 +241,7 @@ export function buildSeriesPlansJson(
 export function buildSeriesWriteBody(
   data: SeriesFormData,
   featured: boolean,
+  groupId?: string,
 ): SeriesPayload {
   const metadata = buildSeriesMetadata(data.languages);
   const languageCodes = metadata.map((m) => m.language);
@@ -248,21 +251,24 @@ export function buildSeriesWriteBody(
     featured,
     plans: buildSeriesPlansJson(data, languageCodes),
     ...(imageKey ? { image_key: imageKey } : {}),
+    ...(groupId ? { group_id: groupId } : {}),
   };
 }
 
 export function buildSeriesCreateBody(
   data: SeriesFormData,
   featured = false,
+  groupId?: string,
 ): SeriesPayload {
-  return buildSeriesWriteBody(data, featured);
+  return buildSeriesWriteBody(data, featured, groupId);
 }
 
 export function buildSeriesUpdateBody(
   data: SeriesFormData,
   featured: boolean,
+  groupId?: string,
 ): SeriesPayload {
-  return buildSeriesWriteBody(data, featured);
+  return buildSeriesWriteBody(data, featured, groupId);
 }
 
 export function buildSeriesPlansPayloadFromIds(

--- a/src/components/routes/create-series/api/seriesApi.ts
+++ b/src/components/routes/create-series/api/seriesApi.ts
@@ -27,7 +27,16 @@ export type SeriesPlanDTO = {
   description?: string | null;
   language: string;
   image_url?: string | null;
+  plan_image_url?: string | null;
   image_key?: string | null;
+  image?:
+    | string
+    | {
+        medium?: string | null;
+        thumbnail?: string | null;
+        original?: string | null;
+      }
+    | null;
   display_order?: number | null;
   total_days?: number | null;
   status?: string;

--- a/src/components/routes/create-series/components/PlanSearchSelector.tsx
+++ b/src/components/routes/create-series/components/PlanSearchSelector.tsx
@@ -29,6 +29,8 @@ type PlanSearchSelectorProps = {
   value: SeriesPlan[];
   onChange: (plans: SeriesPlan[]) => void;
   searchLanguage?: string;
+  /** Only plans in this group can be searched and added. */
+  groupId?: string;
   /** Hide the inline selected list (e.g. series details shows plans in a table). */
   hideSelectedList?: boolean;
   searchPlaceholder?: string;
@@ -39,6 +41,7 @@ const PlanSearchSelector = ({
   value,
   onChange,
   searchLanguage,
+  groupId,
   hideSelectedList = false,
   searchPlaceholder = "Find plans to add",
   className = "",
@@ -56,20 +59,21 @@ const PlanSearchSelector = ({
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteQuery({
-      queryKey: ["search-plans", debouncedQuery, searchLanguage],
+      queryKey: ["search-plans", debouncedQuery, searchLanguage, groupId],
       queryFn: ({ pageParam = 0 }) =>
         searchPlans({
           search: debouncedQuery || undefined,
           language: searchLanguage,
           skip: pageParam,
           limit: PAGE_SIZE,
+          ...(groupId ? { group_id: groupId } : {}),
         }),
       getNextPageParam: (lastPage) => {
         const fetched = lastPage.skip + lastPage.plans.length;
         return fetched < lastPage.total ? fetched : undefined;
       },
       initialPageParam: 0,
-      enabled: isDropdownOpen,
+      enabled: isDropdownOpen && Boolean(groupId),
     });
 
   const searchResults: Plan[] = data?.pages.flatMap((page) => page.plans) ?? [];
@@ -104,9 +108,10 @@ const PlanSearchSelector = ({
     if (next) onChange(next);
   };
 
-  const showDropdown = isDropdownOpen;
+  const showDropdown = isDropdownOpen && Boolean(groupId);
   const showNoResults =
     showDropdown && !isLoading && searchResults.length === 0;
+  const showMissingGroup = isDropdownOpen && !groupId;
 
   const sortableIds = value.map((p) => p.id);
   const canReorder = value.length > 1;
@@ -181,6 +186,14 @@ const PlanSearchSelector = ({
             className="h-12 w-full rounded-md border border-input bg-white dark:bg-[#262626] dark:text-white pl-10 pr-3 text-base placeholder:text-muted-foreground focus-visible:outline-none"
           />
         </div>
+
+        {showMissingGroup && (
+          <div className="absolute z-10 mt-1 w-full rounded-md border border-input bg-background dark:bg-[#262626] shadow-md px-3 py-2">
+            <p className="text-sm text-muted-foreground">
+              Save the series with a group before adding plans.
+            </p>
+          </div>
+        )}
 
         {showDropdown && (
           <div className="absolute z-10 mt-1 w-full rounded-md border border-input bg-background dark:bg-[#262626] shadow-md max-h-60 overflow-auto">

--- a/src/components/routes/create-series/hooks/useSeriesForm.ts
+++ b/src/components/routes/create-series/hooks/useSeriesForm.ts
@@ -70,8 +70,12 @@ export const useSeriesForm = (): UseSeriesFormReturn => {
     (code: LanguageCode) => {
       const currentLanguages = form.getValues("languages") ?? {};
       const currentPlans = form.getValues("plans") ?? {};
-      const { [code]: _l, ...restLanguages } = currentLanguages;
-      const { [code]: _p, ...restPlans } = currentPlans;
+      const restLanguages = Object.fromEntries(
+        Object.entries(currentLanguages).filter(([key]) => key !== code),
+      ) as typeof currentLanguages;
+      const restPlans = Object.fromEntries(
+        Object.entries(currentPlans).filter(([key]) => key !== code),
+      ) as typeof currentPlans;
       form.setValue("languages", restLanguages, {
         shouldDirty: true,
         shouldValidate: true,

--- a/src/components/routes/dashboard/Dashboard.test.tsx
+++ b/src/components/routes/dashboard/Dashboard.test.tsx
@@ -39,7 +39,7 @@ describe("Dashboard Component", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders dashboard with search input and add button", () => {
+  it("renders dashboard with search input", () => {
     vi.spyOn(axiosInstance, "get").mockResolvedValue({
       data: emptyDashboardResponse,
     });
@@ -48,8 +48,6 @@ describe("Dashboard Component", () => {
     expect(
       screen.getByPlaceholderText("common.placeholder.search"),
     ).toBeDefined();
-
-    expect(screen.getByLabelText("Add")).toBeDefined();
   });
 
   it("displays table headers correctly", async () => {
@@ -110,31 +108,6 @@ describe("Dashboard Component", () => {
     fireEvent.change(searchInput, { target: { value: "test search" } });
 
     expect(searchInput.value).toBe("test search");
-  });
-
-  it("renders add dropdown with plan and series links", async () => {
-    vi.spyOn(axiosInstance, "get").mockResolvedValue({
-      data: emptyDashboardResponse,
-    });
-    const user = userEvent.setup();
-    renderWithProviders(<Dashboard />);
-
-    await waitFor(() => {
-      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-    });
-
-    await user.click(screen.getByLabelText("Add"));
-
-    expect(
-      await screen.findByRole("menuitem", { name: "Add Plan" }),
-    ).toBeInTheDocument();
-    const addPlanItem = screen.getByRole("menuitem", { name: "Add Plan" });
-    expect(addPlanItem.closest("a")?.getAttribute("href")).toBe("/plan/new");
-
-    const addSeriesItem = screen.getByRole("menuitem", { name: "Add Series" });
-    expect(addSeriesItem.closest("a")?.getAttribute("href")).toBe(
-      "/series/new",
-    );
   });
 
   it("has proper table structure when items exist", async () => {

--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -131,26 +131,13 @@ const Dashboard = () => {
     isLoading: isGroupFilterLoading,
     showFilter: showGroupFilter,
     isStaffWideList: isStaffWideGroupList,
-  } = useDashboardGroupFilterOptions(userInfo?.platform_role);
+    allowedGroupIds,
+  } = useDashboardGroupFilterOptions(userInfo);
 
   const fetchParams = useMemo(
     () => dashboardUrlStateToFetchParams(urlState),
     [urlState],
   );
-
-  useEffect(() => {
-    if (!urlState.groupId || isGroupFilterLoading) return;
-    const allowed = new Set(groupFilterOptions.map((g) => g.id));
-    if (!allowed.has(urlState.groupId)) {
-      replaceUrlState({ groupId: null, ...resetPageFilters });
-    }
-  }, [
-    urlState.groupId,
-    groupFilterOptions,
-    isGroupFilterLoading,
-    replaceUrlState,
-    resetPageFilters,
-  ]);
 
   const {
     data: dashboardData,
@@ -201,6 +188,22 @@ const Dashboard = () => {
   };
 
   const rows = dashboardData?.rows ?? [];
+
+  useEffect(() => {
+    if (isStaffWideGroupList) return;
+    if (!urlState.groupId || isGroupFilterLoading) return;
+    if (!allowedGroupIds.has(urlState.groupId)) {
+      replaceUrlState({ groupId: null, ...resetPageFilters });
+    }
+  }, [
+    urlState.groupId,
+    allowedGroupIds,
+    isGroupFilterLoading,
+    isStaffWideGroupList,
+    replaceUrlState,
+    resetPageFilters,
+  ]);
+
   const groupRolesByGroupId = useGroupRolesMap(
     rows.map((r) => r.group_id),
     userInfo
@@ -246,7 +249,7 @@ const Dashboard = () => {
       {showGroupFilter ? (
         <div className="flex min-w-[200px] flex-col gap-1">
           <span className="text-xs font-medium text-muted-foreground">
-            {isStaffWideGroupList ? "Group (all)" : "Group (yours)"}
+            Group
           </span>
           <Pecha.Select
             value={groupFilterValue}
@@ -269,7 +272,7 @@ const Dashboard = () => {
               <Pecha.SelectItem value="all">All groups</Pecha.SelectItem>
               {groupFilterOptions.map((group) => (
                 <Pecha.SelectItem key={group.id} value={group.id}>
-                  {group.title}
+                  {group.label}
                 </Pecha.SelectItem>
               ))}
             </Pecha.SelectContent>

--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -25,7 +25,6 @@ import {
 } from "react";
 import { useDebounce } from "use-debounce";
 import { useTolgee, useTranslate } from "@tolgee/react";
-import { Button } from "@/components/ui/atoms/button";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
 import { Link, useSearchParams } from "react-router-dom";

--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -14,7 +14,7 @@ import {
   type DashboardSort,
   type DashboardUrlState,
 } from "@/components/routes/dashboard/dashboardUrlState";
-import { IoMdAdd, IoMdSearch } from "react-icons/io";
+import { IoMdSearch } from "react-icons/io";
 import {
   useCallback,
   useEffect,
@@ -25,7 +25,6 @@ import {
 } from "react";
 import { useDebounce } from "use-debounce";
 import { useTranslate } from "@tolgee/react";
-import { Button } from "@/components/ui/atoms/button";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
 import { Link, useSearchParams } from "react-router-dom";
@@ -33,6 +32,10 @@ import { ROUTES } from "@/routes/paths";
 import { Pagination } from "@/components/ui/molecules/pagination/Pagination";
 import AuthButton from "@/components/ui/molecules/auth-button/AuthButton";
 import { toast } from "sonner";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { useGroupRolesMap } from "@/hooks/useGroupRolesMap";
+import { useDashboardGroupFilterOptions } from "@/hooks/useDashboardGroupFilterOptions";
+import { isReviewer } from "@/lib/platformAccess";
 
 const SEARCH_DEBOUNCE_MS = 500;
 
@@ -83,6 +86,7 @@ function DashboardListPlaceholder({
 
 const Dashboard = () => {
   const { t } = useTranslate();
+  const { data: userInfo } = useUserInfo();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const urlState = useMemo(
@@ -105,7 +109,7 @@ const Dashboard = () => {
     [urlState, setSearchParams],
   );
 
-  const resetPageFilters = { page: 1 as const };
+  const resetPageFilters = useMemo(() => ({ page: 1 as const }), []);
 
   useEffect(() => {
     const trimmed = debouncedSearchDraft.trim();
@@ -115,12 +119,38 @@ const Dashboard = () => {
       search: trimmed || null,
       ...resetPageFilters,
     });
-  }, [debouncedSearchDraft, urlState.search, replaceUrlState]);
+  }, [
+    debouncedSearchDraft,
+    urlState.search,
+    replaceUrlState,
+    resetPageFilters,
+  ]);
+
+  const {
+    options: groupFilterOptions,
+    isLoading: isGroupFilterLoading,
+    showFilter: showGroupFilter,
+    isStaffWideList: isStaffWideGroupList,
+  } = useDashboardGroupFilterOptions(userInfo?.platform_role);
 
   const fetchParams = useMemo(
     () => dashboardUrlStateToFetchParams(urlState),
     [urlState],
   );
+
+  useEffect(() => {
+    if (!urlState.groupId || isGroupFilterLoading) return;
+    const allowed = new Set(groupFilterOptions.map((g) => g.id));
+    if (!allowed.has(urlState.groupId)) {
+      replaceUrlState({ groupId: null, ...resetPageFilters });
+    }
+  }, [
+    urlState.groupId,
+    groupFilterOptions,
+    isGroupFilterLoading,
+    replaceUrlState,
+    resetPageFilters,
+  ]);
 
   const {
     data: dashboardData,
@@ -171,6 +201,17 @@ const Dashboard = () => {
   };
 
   const rows = dashboardData?.rows ?? [];
+  const groupRolesByGroupId = useGroupRolesMap(
+    rows.map((r) => r.group_id),
+    userInfo
+      ? {
+          id: userInfo.id,
+          email: userInfo.email,
+          platform_role: userInfo.platform_role,
+        }
+      : undefined,
+  );
+  const platformReadOnly = isReviewer(userInfo?.platform_role);
   const hasRows = rows.length > 0;
   const isLoadingTable = status === "pending" || isFetching;
   const showEmpty = status === "success" && !hasRows;
@@ -198,8 +239,43 @@ const Dashboard = () => {
 
   const sortValue: DashboardSort = urlState.sort ?? "recent";
 
+  const groupFilterValue = urlState.groupId ?? "all";
+
   const filterBar = (
     <div className="flex w-full flex-wrap items-end gap-4 px-4 pb-2 pt-3">
+      {showGroupFilter ? (
+        <div className="flex min-w-[200px] flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">
+            {isStaffWideGroupList ? "Group (all)" : "Group (yours)"}
+          </span>
+          <Pecha.Select
+            value={groupFilterValue}
+            onValueChange={(v) => {
+              replaceUrlState({
+                groupId: v === "all" ? null : v,
+                ...resetPageFilters,
+              });
+            }}
+            disabled={isGroupFilterLoading}
+          >
+            <Pecha.SelectTrigger className="h-9 w-[220px] bg-white dark:bg-input/30">
+              <Pecha.SelectValue
+                placeholder={
+                  isGroupFilterLoading ? "Loading groups…" : "All groups"
+                }
+              />
+            </Pecha.SelectTrigger>
+            <Pecha.SelectContent>
+              <Pecha.SelectItem value="all">All groups</Pecha.SelectItem>
+              {groupFilterOptions.map((group) => (
+                <Pecha.SelectItem key={group.id} value={group.id}>
+                  {group.title}
+                </Pecha.SelectItem>
+              ))}
+            </Pecha.SelectContent>
+          </Pecha.Select>
+        </div>
+      ) : null}
       <div className="flex min-w-[180px] flex-col gap-1">
         <span className="text-xs font-medium text-muted-foreground">Sort</span>
         <Pecha.Select
@@ -285,31 +361,6 @@ const Dashboard = () => {
             />
           </div>
 
-          <Pecha.DropdownMenu>
-            <Pecha.DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className="gap-2 border-gray-200 bg-white hover:bg-gray-50 dark:border-[#313132] dark:bg-transparent dark:hover:bg-[#2a2a2a]"
-                aria-label="Add"
-              >
-                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#A51C21] text-white">
-                  <IoMdAdd className="h-4 w-4" aria-hidden />
-                </span>
-                Add
-              </Button>
-            </Pecha.DropdownMenuTrigger>
-            <Pecha.DropdownMenuContent align="start">
-              <Pecha.DropdownMenuGroup>
-                <Link to={ROUTES.seriesNew}>
-                  <Pecha.DropdownMenuItem>Add Series</Pecha.DropdownMenuItem>
-                </Link>
-                <Link to={ROUTES.planNew}>
-                  <Pecha.DropdownMenuItem>Add Plan</Pecha.DropdownMenuItem>
-                </Link>
-              </Pecha.DropdownMenuGroup>
-            </Pecha.DropdownMenuContent>
-          </Pecha.DropdownMenu>
-
           <div className="flex flex-wrap items-center gap-2 pl-1">
             <button
               type="button"
@@ -348,16 +399,13 @@ const Dashboard = () => {
         ) : showEmpty ? (
           <DashboardListPlaceholder
             title={emptyTitle}
-            description={emptyDescription}
+            description={
+              emptyDescription ?? "Create plans and series from a group page."
+            }
           >
-            <Link to={ROUTES.planNew}>
+            <Link to={ROUTES.groups}>
               <Pecha.Button variant="outline" size="sm">
-                <IoMdAdd className="h-4 w-4" /> {t("studio.dashboard.add_plan")}
-              </Pecha.Button>
-            </Link>
-            <Link to={ROUTES.seriesNew}>
-              <Pecha.Button variant="outline" size="sm">
-                <IoMdAdd className="h-4 w-4" /> Add Series
+                Go to groups
               </Pecha.Button>
             </Link>
           </DashboardListPlaceholder>
@@ -367,7 +415,10 @@ const Dashboard = () => {
               rows={rows}
               isLoading={isLoadingTable}
               t={t}
-              handleFeatured={handleFeatured}
+              handleFeatured={platformReadOnly ? () => {} : handleFeatured}
+              platformRole={userInfo?.platform_role}
+              groupRolesByGroupId={groupRolesByGroupId}
+              userInfo={userInfo}
             />
           </div>
         )}

--- a/src/components/routes/dashboard/DashboardContentTable.test.tsx
+++ b/src/components/routes/dashboard/DashboardContentTable.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { useTranslate } from "@tolgee/react";
 import { describe, expect, it, vi } from "vitest";
 import { DashboardContentTable } from "./DashboardContentTable";
 import type { DashboardTableRow } from "./dashboardTable";
 
-const t = (key: string) => key;
+const t = ((key: string) => key) as ReturnType<typeof useTranslate>["t"];
 
 const sampleRow: DashboardTableRow = {
   id: "plan-1",

--- a/src/components/routes/dashboard/DashboardContentTable.test.tsx
+++ b/src/components/routes/dashboard/DashboardContentTable.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { DashboardContentTable } from "./DashboardContentTable";
+import type { DashboardTableRow } from "./dashboardTable";
+
+const t = (key: string) => key;
+
+const sampleRow: DashboardTableRow = {
+  id: "plan-1",
+  kind: "plan",
+  title: "Sample plan",
+  image_url: "",
+  status: "DRAFT",
+  featured: false,
+  languages: ["EN"],
+  enrolled: 0,
+  total_days: 7,
+  modifiedAt: "2025-01-01T00:00:00Z",
+};
+
+describe("DashboardContentTable", () => {
+  it("hides actions column for platform reviewers", () => {
+    render(
+      <BrowserRouter>
+        <DashboardContentTable
+          rows={[sampleRow]}
+          t={t}
+          handleFeatured={vi.fn()}
+          platformRole="REVIEWER"
+        />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText("Sample plan")).toBeInTheDocument();
+    expect(
+      screen.queryByText("studio.dashboard.actions"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows actions column for creators", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <DashboardContentTable
+            rows={[sampleRow]}
+            t={t}
+            handleFeatured={vi.fn()}
+            platformRole="CREATOR"
+            userInfo={{
+              id: "u1",
+              platform_role: "CREATOR",
+              can_create_content: true,
+            }}
+          />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText("studio.dashboard.actions")).toBeInTheDocument();
+  });
+});

--- a/src/components/routes/dashboard/DashboardContentTable.tsx
+++ b/src/components/routes/dashboard/DashboardContentTable.tsx
@@ -16,6 +16,16 @@ import {
 } from "./dashboardTable";
 import { ROUTES } from "@/routes/paths";
 import { FeaturedStar, languageChip, statusChip } from "./dashboardTableUi";
+import type { PlatformRole } from "@/lib/platformAccess";
+import {
+  canAccessPlanRoutes,
+  isReviewer,
+  shouldShowCmsActionsColumn,
+} from "@/lib/platformAccess";
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+import { canChangeContentStatus } from "@/lib/contentPermissions";
+import { resolveDashboardRowGroupRole } from "@/lib/dashboardRowPermissions";
+import type { UserInfo } from "@/hooks/useUserInfo";
 
 interface DashboardContentTableProps {
   rows: DashboardTableRow[];
@@ -26,6 +36,9 @@ interface DashboardContentTableProps {
     kind: DashboardTableRow["kind"],
     featured: boolean,
   ) => void;
+  platformRole?: PlatformRole;
+  groupRolesByGroupId?: Map<string, AuthorGroupMemberRole | undefined>;
+  userInfo?: UserInfo | null;
 }
 
 export function DashboardContentTable({
@@ -33,14 +46,27 @@ export function DashboardContentTable({
   // isLoading,
   t,
   handleFeatured,
+  platformRole,
+  groupRolesByGroupId,
+  userInfo,
 }: DashboardContentTableProps) {
   const navigate = useNavigate();
+  const platformReadOnly = isReviewer(platformRole);
+  const showActionsColumn = shouldShowCmsActionsColumn(platformRole);
 
   const renderBody = () => {
     return rows.map((row) => {
+      const groupRole = resolveDashboardRowGroupRole(
+        row,
+        groupRolesByGroupId,
+        userInfo,
+      );
+      const canFeature = canChangeContentStatus(groupRole, platformRole);
       const daysLabel = `${row.total_days} ${row.total_days === 1 ? "Day" : "Days"}`;
       const titleHref =
         row.kind === "plan" ? ROUTES.plan(row.id) : ROUTES.series(row.id);
+      const canOpenTitle =
+        row.kind === "series" || canAccessPlanRoutes(platformRole);
       const modifiedDisplay = formatRowModified(row);
       const canToggleFeatured =
         row.kind === "series" ||
@@ -74,24 +100,41 @@ export function DashboardContentTable({
             </div>
           </Pecha.TableCell>
           <Pecha.TableCell>
-            <button
-              type="button"
-              className="text-left cursor-pointer"
-              onClick={() => navigate(titleHref)}
-            >
-              <div className="text-sm font-semibold">{row.title}</div>
-              <div className="mt-1.5 flex flex-wrap gap-1.5">
-                {row.languages?.map((code: DashboardLanguageCode) => (
-                  <span key={`${row.id}-${code}`}>{languageChip(code)}</span>
-                ))}
-                {statusChip(row.status)}
-                {row.kind === "plan" && (
-                  <span className="rounded-full bg-[#DEAD2D4D] px-2.5 py-0.5 text-xs font-medium text-[#020C1D] dark:bg-[#DEAD2D4D] dark:text-white">
-                    {daysLabel}
-                  </span>
-                )}
+            {canOpenTitle ? (
+              <button
+                type="button"
+                className="text-left cursor-pointer"
+                onClick={() => navigate(titleHref)}
+              >
+                <div className="text-sm font-semibold">{row.title}</div>
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {row.languages?.map((code: DashboardLanguageCode) => (
+                    <span key={`${row.id}-${code}`}>{languageChip(code)}</span>
+                  ))}
+                  {statusChip(row.status)}
+                  {row.kind === "plan" && (
+                    <span className="rounded-full bg-[#DEAD2D4D] px-2.5 py-0.5 text-xs font-medium text-[#020C1D] dark:bg-[#DEAD2D4D] dark:text-white">
+                      {daysLabel}
+                    </span>
+                  )}
+                </div>
+              </button>
+            ) : (
+              <div className="text-left">
+                <div className="text-sm font-semibold">{row.title}</div>
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {row.languages?.map((code: DashboardLanguageCode) => (
+                    <span key={`${row.id}-${code}`}>{languageChip(code)}</span>
+                  ))}
+                  {statusChip(row.status)}
+                  {row.kind === "plan" && (
+                    <span className="rounded-full bg-[#DEAD2D4D] px-2.5 py-0.5 text-xs font-medium text-[#020C1D] dark:bg-[#DEAD2D4D] dark:text-white">
+                      {daysLabel}
+                    </span>
+                  )}
+                </div>
               </div>
-            </button>
+            )}
           </Pecha.TableCell>
           <Pecha.TableCell className="text-sm text-center">
             {row.enrolled}
@@ -100,7 +143,7 @@ export function DashboardContentTable({
             {modifiedDisplay}
           </Pecha.TableCell>
           <Pecha.TableCell className="text-center">
-            {canToggleFeatured ? (
+            {canToggleFeatured && canFeature && !platformReadOnly ? (
               <Pecha.Button
                 type="button"
                 variant="outline"
@@ -124,37 +167,43 @@ export function DashboardContentTable({
               </span>
             )}
           </Pecha.TableCell>
-          <Pecha.TableCell className="px-auto">
-            {row.kind === "plan" && isMockDashboardId(row.id) ? (
-              <Pecha.DropdownMenu>
-                <Pecha.DropdownMenuTrigger asChild>
-                  <Pecha.Button
-                    variant="outline"
-                    size="icon"
-                    aria-label="Actions"
+          {showActionsColumn ? (
+            <Pecha.TableCell className="px-auto">
+              {row.kind === "plan" && isMockDashboardId(row.id) ? (
+                <Pecha.DropdownMenu>
+                  <Pecha.DropdownMenuTrigger asChild>
+                    <Pecha.Button
+                      variant="outline"
+                      size="icon"
+                      aria-label="Actions"
+                    >
+                      <BsThreeDotsVertical />
+                    </Pecha.Button>
+                  </Pecha.DropdownMenuTrigger>
+                  <Pecha.DropdownMenuContent
+                    align="end"
+                    className="[--radius:1rem]"
                   >
-                    <BsThreeDotsVertical />
-                  </Pecha.Button>
-                </Pecha.DropdownMenuTrigger>
-                <Pecha.DropdownMenuContent
-                  align="end"
-                  className="[--radius:1rem]"
-                >
-                  <Pecha.DropdownMenuItem disabled>
-                    Preview (mock)
-                  </Pecha.DropdownMenuItem>
-                </Pecha.DropdownMenuContent>
-              </Pecha.DropdownMenu>
-            ) : (
-              <DropdownButton
-                id={row.id}
-                entityType={row.kind}
-                currentStatus={row.status}
-                triggerVariant="icon"
-                triggerClassName={DASHBOARD_TABLE_ICON_BTN}
-              />
-            )}
-          </Pecha.TableCell>
+                    <Pecha.DropdownMenuItem disabled>
+                      Preview (mock)
+                    </Pecha.DropdownMenuItem>
+                  </Pecha.DropdownMenuContent>
+                </Pecha.DropdownMenu>
+              ) : (
+                <DropdownButton
+                  id={row.id}
+                  entityType={row.kind}
+                  currentStatus={row.status}
+                  triggerVariant="icon"
+                  triggerClassName={DASHBOARD_TABLE_ICON_BTN}
+                  platformRole={platformRole}
+                  groupRole={groupRole}
+                  sourceGroupId={row.group_id}
+                  contentTitle={row.title}
+                />
+              )}
+            </Pecha.TableCell>
+          ) : null}
         </Pecha.TableRow>
       );
     });
@@ -179,9 +228,11 @@ export function DashboardContentTable({
           <Pecha.TableHead className="w-[72px] font-bold text-center">
             Featured
           </Pecha.TableHead>
-          <Pecha.TableHead className="w-[100px] font-bold text-center">
-            {t("studio.dashboard.actions")}
-          </Pecha.TableHead>
+          {showActionsColumn ? (
+            <Pecha.TableHead className="w-[100px] font-bold text-center">
+              {t("studio.dashboard.actions")}
+            </Pecha.TableHead>
+          ) : null}
         </Pecha.TableRow>
       </Pecha.TableHeader>
       <Pecha.TableBody>{renderBody()}</Pecha.TableBody>

--- a/src/components/routes/dashboard/dashboardApi.test.ts
+++ b/src/components/routes/dashboard/dashboardApi.test.ts
@@ -6,6 +6,29 @@ import {
 import { fetchDashboardItems } from "./dashboardApi";
 import axiosInstance from "@/config/axios-config";
 import { vi } from "vitest";
+import { resolveDashboardItemImageUrl } from "./dashboardTable";
+
+describe("resolveDashboardItemImageUrl", () => {
+  it("uses medium from nested image object", () => {
+    expect(
+      resolveDashboardItemImageUrl({
+        image: {
+          medium: "https://example.com/medium.jpg",
+          original: "https://example.com/original.jpg",
+        },
+      }),
+    ).toBe("https://example.com/medium.jpg");
+  });
+
+  it("prefers image_url over nested image", () => {
+    expect(
+      resolveDashboardItemImageUrl({
+        image_url: "https://example.com/direct.jpg",
+        image: { medium: "https://example.com/medium.jpg" },
+      }),
+    ).toBe("https://example.com/direct.jpg");
+  });
+});
 
 describe("displayDashboardItemTitle", () => {
   it("uses plan title for plan rows", () => {
@@ -78,6 +101,9 @@ describe("fetchDashboardItems", () => {
                 language: "EN",
               },
             ],
+            image: {
+              medium: "https://example.com/series-cover.jpg",
+            },
             status: "PUBLISHED",
             featured: false,
             languages: ["EN"],
@@ -96,6 +122,9 @@ describe("fetchDashboardItems", () => {
     });
 
     expect(result.rows[0]?.title).toBe("Test Series");
+    expect(result.rows[0]?.image_url).toBe(
+      "https://example.com/series-cover.jpg",
+    );
     vi.restoreAllMocks();
   });
 });

--- a/src/components/routes/dashboard/dashboardApi.ts
+++ b/src/components/routes/dashboard/dashboardApi.ts
@@ -4,6 +4,8 @@ import {
   normalizeStatus,
   parseDashboardLanguages,
   pickSeriesTitle,
+  resolveDashboardItemImageUrl,
+  type DashboardImageVariants,
   type DashboardTableRow,
 } from "./dashboardTable";
 
@@ -21,7 +23,7 @@ function mapDashboardItemToTableRow(item: DashboardApiItem): DashboardTableRow {
     kind: item.type,
     id: String(item.id),
     title: displayDashboardItemTitle(item),
-    image_url: item.image_url ?? "",
+    image_url: resolveDashboardItemImageUrl(item),
     languages: parseDashboardLanguages(item.languages),
     status: normalizeStatus(item.status),
     total_days: item.total_days ?? 0,
@@ -51,11 +53,13 @@ export interface DashboardApiItem {
   /** Plans only; omitted from JSON for series. */
   title?: string;
   metadata?: DashboardSeriesMetadataDTO[];
-  author_id?: string;
+  author_id?: string | null;
   group_id?: string | null;
   series_id?: string | null;
   image_url?: string | null;
+  plan_image_url?: string | null;
   image_key?: string | null;
+  image?: string | DashboardImageVariants | null;
   status: string;
   featured: boolean;
   languages: string[];

--- a/src/components/routes/dashboard/dashboardApi.ts
+++ b/src/components/routes/dashboard/dashboardApi.ts
@@ -1,4 +1,5 @@
 import axiosInstance from "@/config/axios-config";
+import { enrichDashboardRows } from "./enrichDashboardRows";
 import {
   normalizeStatus,
   parseDashboardLanguages,
@@ -27,6 +28,8 @@ function mapDashboardItemToTableRow(item: DashboardApiItem): DashboardTableRow {
     enrolled: item.enrolled_count ?? 0,
     modifiedAt: item.updated_at ?? item.created_at ?? null,
     featured: !!item.featured,
+    group_id: item.group_id ?? null,
+    series_id: item.series_id ?? null,
     ...(item.type === "series" && {
       plans_count: item.plans_count ?? 0,
     }),
@@ -49,6 +52,8 @@ export interface DashboardApiItem {
   title?: string;
   metadata?: DashboardSeriesMetadataDTO[];
   author_id?: string;
+  group_id?: string | null;
+  series_id?: string | null;
   image_url?: string | null;
   image_key?: string | null;
   status: string;
@@ -81,6 +86,7 @@ export interface FetchDashboardItemsParams {
   status?: string;
   language?: string;
   featured?: boolean;
+  group_id?: string;
 }
 
 export interface DashboardItemsResult {
@@ -108,6 +114,7 @@ export async function fetchDashboardItems(
         ...(params.status && { status: params.status }),
         ...(params.language && { language: params.language }),
         ...(params.featured != null && { featured: params.featured }),
+        ...(params.group_id && { group_id: params.group_id }),
       },
     },
   );
@@ -120,8 +127,10 @@ export async function fetchDashboardItems(
     total_pages: items.length > 0 ? 1 : 0,
   };
 
+  const rows = await enrichDashboardRows(items.map(mapDashboardItemToTableRow));
+
   return {
-    rows: items.map(mapDashboardItemToTableRow),
+    rows,
     pagination,
   };
 }

--- a/src/components/routes/dashboard/dashboardTable.ts
+++ b/src/components/routes/dashboard/dashboardTable.ts
@@ -25,6 +25,43 @@ export interface DashboardTableRow {
   series_id?: string | null;
 }
 
+export type DashboardImageVariants = {
+  thumbnail?: string | null;
+  medium?: string | null;
+  original?: string | null;
+};
+
+export type DashboardItemImageFields = {
+  image_url?: string | null;
+  plan_image_url?: string | null;
+  image_key?: string | null;
+  image?: string | DashboardImageVariants | null;
+};
+
+/** Resolve a display URL from dashboard/list API image fields. */
+export function resolveDashboardItemImageUrl(
+  item: DashboardItemImageFields,
+): string {
+  const direct = item.image_url?.trim() || item.plan_image_url?.trim();
+  if (direct) return direct;
+
+  const image = item.image;
+  if (image && typeof image === "object") {
+    return (
+      image.medium?.trim() ||
+      image.thumbnail?.trim() ||
+      image.original?.trim() ||
+      ""
+    );
+  }
+  if (typeof image === "string" && image.trim()) return image.trim();
+
+  const key = item.image_key?.trim();
+  if (key && /^https?:\/\//i.test(key)) return key;
+
+  return "";
+}
+
 function normalizeOneLanguageCode(v: string): DashboardLanguageCode | null {
   const u = v.trim().toUpperCase();
   if (u === "EN" || u === "ZH" || u === "BO") return u;
@@ -113,7 +150,12 @@ export function mapPlanToTableRow(
     kind: "plan",
     id: String(plan.id ?? ""),
     title: String(plan.title ?? "Untitled"),
-    image_url: String(plan.image_url ?? ""),
+    image_url: resolveDashboardItemImageUrl({
+      image_url: plan.image_url as string | null | undefined,
+      plan_image_url: plan.plan_image_url as string | null | undefined,
+      image_key: plan.image_key as string | null | undefined,
+      image: plan.image as DashboardItemImageFields["image"],
+    }),
     languages: parseDashboardLanguages(
       plan.languages ?? plan.language ?? plan.language_codes,
     ),
@@ -152,7 +194,11 @@ export function mapSeriesToTableRow(
     kind: "series",
     id: String(s.id ?? ""),
     title,
-    image_url: String(s.image_url ?? s.image ?? ""),
+    image_url: resolveDashboardItemImageUrl({
+      image_url: s.image_url as string | null | undefined,
+      image_key: s.image_key as string | null | undefined,
+      image: s.image as DashboardItemImageFields["image"],
+    }),
     languages: parseDashboardLanguages(
       s.languages ?? s.language ?? s.language_codes ?? firstLang,
     ),

--- a/src/components/routes/dashboard/dashboardTable.ts
+++ b/src/components/routes/dashboard/dashboardTable.ts
@@ -21,6 +21,8 @@ export interface DashboardTableRow {
   dateModifiedLabel?: string;
   featured: boolean;
   plans_count?: number;
+  group_id?: string | null;
+  series_id?: string | null;
 }
 
 function normalizeOneLanguageCode(v: string): DashboardLanguageCode | null {

--- a/src/components/routes/dashboard/dashboardUrlState.test.ts
+++ b/src/components/routes/dashboard/dashboardUrlState.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDashboardSearchParams,
+  dashboardUrlStateToFetchParams,
+  parseDashboardSearchParams,
+} from "./dashboardUrlState";
+
+describe("dashboardUrlState group filter", () => {
+  it("parses and builds group_id in URL", () => {
+    const params = new URLSearchParams();
+    params.set("group_id", "abc-123");
+    const state = parseDashboardSearchParams(params);
+    expect(state.groupId).toBe("abc-123");
+
+    const built = buildDashboardSearchParams(state);
+    expect(built.get("group_id")).toBe("abc-123");
+  });
+
+  it("passes group_id to dashboard fetch params", () => {
+    const fetchParams = dashboardUrlStateToFetchParams({
+      tab: "all",
+      page: 1,
+      pageSize: 10,
+      search: null,
+      status: null,
+      language: null,
+      featured: null,
+      sort: null,
+      groupId: "group-1",
+    });
+    expect(fetchParams.group_id).toBe("group-1");
+  });
+});

--- a/src/components/routes/dashboard/dashboardUrlState.ts
+++ b/src/components/routes/dashboard/dashboardUrlState.ts
@@ -21,6 +21,7 @@ export interface DashboardUrlState {
   language: string | null;
   featured: boolean | null;
   sort: DashboardSort | null;
+  groupId: string | null;
 }
 
 export const DASHBOARD_URL_DEFAULTS: DashboardUrlState = {
@@ -32,6 +33,7 @@ export const DASHBOARD_URL_DEFAULTS: DashboardUrlState = {
   language: null,
   featured: null,
   sort: null,
+  groupId: null,
 };
 
 const VALID_TABS = new Set<DashboardTab>(["all", "series", "plans"]);
@@ -110,6 +112,7 @@ export function parseDashboardSearchParams(
     language: parseLanguage(params.get("language")),
     featured,
     sort: parseSort(params.get("sort")),
+    groupId: params.get("group_id")?.trim() || null,
   };
 }
 
@@ -127,6 +130,7 @@ export function buildDashboardSearchParams(
   if (state.language) p.set("language", state.language);
   if (state.featured !== null) p.set("featured", String(state.featured));
   if (state.sort) p.set("sort", state.sort);
+  if (state.groupId) p.set("group_id", state.groupId);
 
   return p;
 }
@@ -142,6 +146,7 @@ export function dashboardUrlStateToFetchParams(
     ...(state.status && { status: state.status }),
     ...(state.language && { language: state.language }),
     ...(state.featured != null && { featured: state.featured }),
+    ...(state.groupId && { group_id: state.groupId }),
   };
 }
 

--- a/src/components/routes/dashboard/enrichDashboardRows.ts
+++ b/src/components/routes/dashboard/enrichDashboardRows.ts
@@ -1,0 +1,42 @@
+import axiosInstance from "@/config/axios-config";
+import { getSeries } from "@/components/routes/create-series/api/seriesApi";
+import type { DashboardTableRow } from "./dashboardTable";
+
+type CmsPlanDetail = {
+  group_id?: string | null;
+  series_id?: string | null;
+};
+
+/** Dashboard list items may omit group_id; resolve from CMS detail endpoints. */
+export async function enrichDashboardRowWithGroupId(
+  row: DashboardTableRow,
+): Promise<DashboardTableRow> {
+  if (row.group_id) return row;
+
+  try {
+    if (row.kind === "plan") {
+      const { data } = await axiosInstance.get<CmsPlanDetail>(
+        `/api/v1/cms/plans/${row.id}`,
+      );
+      return {
+        ...row,
+        group_id: data.group_id ?? null,
+        series_id: data.series_id ?? row.series_id ?? null,
+      };
+    }
+
+    const series = await getSeries(row.id);
+    return {
+      ...row,
+      group_id: series.group_id ?? null,
+    };
+  } catch {
+    return row;
+  }
+}
+
+export async function enrichDashboardRows(
+  rows: DashboardTableRow[],
+): Promise<DashboardTableRow[]> {
+  return Promise.all(rows.map(enrichDashboardRowWithGroupId));
+}

--- a/src/components/routes/groups/GroupDetailsPage.tsx
+++ b/src/components/routes/groups/GroupDetailsPage.tsx
@@ -1,4 +1,10 @@
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useEffect } from "react";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { IoMdCreate } from "react-icons/io";
 import { Pecha } from "@/components/ui/shadimport";
@@ -6,26 +12,29 @@ import { Button } from "@/components/ui/atoms/button";
 import { getApiErrorMessage } from "@/lib/apiErrors";
 import { useUserInfo } from "@/hooks/useUserInfo";
 import { ROUTES } from "@/routes/paths";
+import { isReviewer } from "@/lib/platformAccess";
 import {
   canEditGroupSettings,
+  canManageGroupInvites,
   getEffectiveGroupRole,
 } from "./lib/groupPermissions";
 import type { LanguageCode } from "@/schema/SeriesSchema";
 import {
   fetchGroup,
   languageLabelForCode,
-  pickGroupLinkedPlanTitle,
-  pickGroupLinkedSeriesTitle,
   pickGroupTitle,
   resolveGroupBannerUrl,
 } from "./api/groupsApi";
 import { GroupDetailCard } from "./components/GroupSection";
-import GroupMembersTable from "./components/GroupMembersTable";
+import GroupMembersPanel from "./components/GroupMembersPanel";
+import GroupContentSection from "./components/GroupContentSection";
+import GroupTransfersSection from "./components/GroupTransfersSection";
 import { GroupPageShell } from "./components/GroupPageShell";
 
 const GroupDetailsPage = () => {
   const { groupId } = useParams<{ groupId: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { data: userInfo } = useUserInfo();
 
   const {
@@ -39,6 +48,12 @@ const GroupDetailsPage = () => {
     enabled: Boolean(groupId),
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    if (searchParams.get("tab") !== "transfers") return;
+    const el = document.getElementById("group-transfers");
+    el?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [searchParams, groupId]);
 
   if (!groupId) return null;
 
@@ -67,6 +82,10 @@ const GroupDetailsPage = () => {
   const memberCount = group.member_count ?? group.members.length;
   const myRole = getEffectiveGroupRole(group.members ?? [], userInfo);
   const canEdit = canEditGroupSettings(myRole);
+  const canManageTransfers =
+    canManageGroupInvites(myRole) || myRole === "OWNER";
+  const readOnlyPlatform = isReviewer(userInfo?.platform_role);
+  const showTransfersSection = !readOnlyPlatform;
 
   return (
     <GroupPageShell
@@ -79,7 +98,7 @@ const GroupDetailsPage = () => {
         </p>
       }
       headerActions={
-        canEdit ? (
+        canEdit && !readOnlyPlatform ? (
           <Button variant="outline" size="sm" asChild>
             <Link to={ROUTES.groupEdit(group.id)}>
               <IoMdCreate className="w-4 h-4" /> Edit
@@ -146,58 +165,21 @@ const GroupDetailsPage = () => {
             </GroupDetailCard>
           )}
 
-          {group.plans.length > 0 && (
-            <GroupDetailCard title="Linked plans">
-              <ul className="space-y-2">
-                {group.plans.map((plan) => (
-                  <li key={plan.id} className="text-sm">
-                    <Link
-                      to={ROUTES.plan(plan.id)}
-                      className="text-[#A51C21] hover:underline font-medium"
-                    >
-                      {pickGroupLinkedPlanTitle(plan)}
-                    </Link>
-                    <span className="text-muted-foreground">
-                      {" "}
-                      · {languageLabelForCode(plan.language)}
-                      {plan.total_days != null ? (
-                        <>
-                          {" "}
-                          · {plan.total_days} day
-                          {plan.total_days === 1 ? "" : "s"}
-                        </>
-                      ) : null}
-                      {plan.status ? <> · {plan.status}</> : null}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </GroupDetailCard>
-          )}
+          <div id="group-transfers">
+            <GroupTransfersSection
+              groupId={group.id}
+              canManageIncoming={canManageTransfers && !readOnlyPlatform}
+              canManageOutgoing={canManageTransfers && !readOnlyPlatform}
+              alwaysVisible={showTransfersSection}
+            />
+          </div>
 
-          {group.series.length > 0 && (
-            <GroupDetailCard title="Linked series">
-              <ul className="space-y-2">
-                {group.series.map((series) => (
-                  <li key={series.id} className="text-sm ">
-                    <Link
-                      to={ROUTES.series(series.id)}
-                      className="text-[#A51C21] hover:underline font-medium"
-                    >
-                      {pickGroupLinkedSeriesTitle(series)}
-                    </Link>
-                    {series.plan_count != null ? (
-                      <span className="text-muted-foreground">
-                        {" "}
-                        · {series.plan_count} plan
-                        {series.plan_count === 1 ? "" : "s"}
-                      </span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            </GroupDetailCard>
-          )}
+          <GroupContentSection
+            groupId={group.id}
+            userInfo={userInfo}
+            groupRole={myRole}
+            readOnlyPlatform={readOnlyPlatform}
+          />
 
           {group.social_links.length > 0 && (
             <GroupDetailCard title="Social links">
@@ -221,11 +203,7 @@ const GroupDetailsPage = () => {
             </GroupDetailCard>
           )}
 
-          {group.members.length > 0 && (
-            <GroupDetailCard title={`Members (${group.members.length})`}>
-              <GroupMembersTable members={group.members} />
-            </GroupDetailCard>
-          )}
+          <GroupMembersPanel groupId={group.id} members={group.members ?? []} />
         </div>
       </div>
     </GroupPageShell>

--- a/src/components/routes/groups/GroupFormPage.tsx
+++ b/src/components/routes/groups/GroupFormPage.tsx
@@ -22,12 +22,8 @@ import {
   languageLabelForCode,
   patchGroup,
   pickGroupTitle,
-  replaceGroupPlans,
-  replaceGroupSeries,
   replaceGroupSocialLinks,
   replaceGroupTags,
-  groupLinkedPlansToFkOptions,
-  groupLinkedSeriesToFkOptions,
   resolveGroupAvatarUrl,
   resolveGroupBannerUrl,
   type GroupSocialLinkDTO,
@@ -37,7 +33,6 @@ import GroupFormAssociationsPanel from "./components/GroupFormAssociationsPanel"
 import GroupImageField from "./components/GroupImageField";
 import { GroupPageShell } from "./components/GroupPageShell";
 import GroupMembersPanel from "./components/GroupMembersPanel";
-import type { FkOption } from "./components/FkMultiSearchSelector";
 import { useUserInfo } from "@/hooks/useUserInfo";
 import {
   canEditGroupSettings,
@@ -47,8 +42,6 @@ import { sameSocialLinks, sameSortedIds } from "./lib/groupFormSectionDirty";
 
 type AssociationBaselines = {
   tagIds: string[];
-  planIds: string[];
-  seriesIds: string[];
   socialLinks: GroupSocialLinkDTO[];
   avatarKey: string | null;
   bannerKey: string | null;
@@ -56,8 +49,6 @@ type AssociationBaselines = {
 
 const emptyAssociationBaselines = (): AssociationBaselines => ({
   tagIds: [],
-  planIds: [],
-  seriesIds: [],
   socialLinks: [],
   avatarKey: null,
   bannerKey: null,
@@ -82,8 +73,6 @@ const GroupFormPage = () => {
   const [bannerUploading, setBannerUploading] = useState(false);
   const [tagIds, setTagIds] = useState<string[]>([]);
   const [initialTags, setInitialTags] = useState<TagSummaryDTO[]>([]);
-  const [selectedPlans, setSelectedPlans] = useState<FkOption[]>([]);
-  const [selectedSeries, setSelectedSeries] = useState<FkOption[]>([]);
   const [socialLinks, setSocialLinks] = useState<GroupSocialLinkDTO[]>([]);
   const [savedBaselines, setSavedBaselines] = useState<AssociationBaselines>(
     emptyAssociationBaselines,
@@ -144,12 +133,8 @@ const GroupFormPage = () => {
     setInitialTags(groupData.tags);
     setSocialLinks(groupData.social_links ?? []);
 
-    setSelectedPlans(groupLinkedPlansToFkOptions(groupData.plans ?? []));
-    setSelectedSeries(groupLinkedSeriesToFkOptions(groupData.series ?? []));
     setSavedBaselines({
       tagIds: groupData.tags.map((t) => t.id),
-      planIds: (groupData.plans ?? []).map((p) => p.id),
-      seriesIds: (groupData.series ?? []).map((s) => s.id),
       socialLinks: groupData.social_links ?? [],
       avatarKey: groupData.avatar_key ?? null,
       bannerKey: groupData.banner_key ?? null,
@@ -226,38 +211,6 @@ const GroupFormPage = () => {
     onError: toastOnError,
   });
 
-  const plansMutation = useMutation({
-    mutationFn: () =>
-      replaceGroupPlans(groupId!, {
-        plan_ids: selectedPlans.map((p) => p.id),
-      }),
-    onSuccess: () => {
-      toast.success("Plans saved");
-      invalidateGroup();
-      setSavedBaselines((prev) => ({
-        ...prev,
-        planIds: selectedPlans.map((p) => p.id),
-      }));
-    },
-    onError: toastOnError,
-  });
-
-  const seriesMutation = useMutation({
-    mutationFn: () =>
-      replaceGroupSeries(groupId!, {
-        series_ids: selectedSeries.map((s) => s.id),
-      }),
-    onSuccess: () => {
-      toast.success("Series saved");
-      invalidateGroup();
-      setSavedBaselines((prev) => ({
-        ...prev,
-        seriesIds: selectedSeries.map((s) => s.id),
-      }));
-    },
-    onError: toastOnError,
-  });
-
   const socialMutation = useMutation({
     mutationFn: () =>
       replaceGroupSocialLinks(groupId!, { social_links: socialLinks }),
@@ -320,14 +273,6 @@ const GroupFormPage = () => {
     bannerKey !== savedBaselines.bannerKey;
   const isCoreDirty = isFormDirty || imagesDirty;
   const tagsDirty = !sameSortedIds(tagIds, savedBaselines.tagIds);
-  const plansDirty = !sameSortedIds(
-    selectedPlans.map((p) => p.id),
-    savedBaselines.planIds,
-  );
-  const seriesDirty = !sameSortedIds(
-    selectedSeries.map((s) => s.id),
-    savedBaselines.seriesIds,
-  );
   const socialDirty = !sameSocialLinks(socialLinks, savedBaselines.socialLinks);
   const myRole = useMemo(
     () =>
@@ -556,23 +501,13 @@ const GroupFormPage = () => {
             tagIds={tagIds}
             onTagIdsChange={setTagIds}
             initialTags={initialTags}
-            selectedPlans={selectedPlans}
-            onPlansChange={setSelectedPlans}
-            selectedSeries={selectedSeries}
-            onSeriesChange={setSelectedSeries}
             socialLinks={socialLinks}
             onSocialLinksChange={setSocialLinks}
             onSaveTags={() => tagsMutation.mutate()}
-            onSavePlans={() => plansMutation.mutate()}
-            onSaveSeries={() => seriesMutation.mutate()}
             onSaveSocial={() => socialMutation.mutate()}
             tagsSaving={tagsMutation.isPending}
-            plansSaving={plansMutation.isPending}
-            seriesSaving={seriesMutation.isPending}
             socialSaving={socialMutation.isPending}
             tagsSaveDisabled={!tagsDirty}
-            plansSaveDisabled={!plansDirty}
-            seriesSaveDisabled={!seriesDirty}
             socialSaveDisabled={!socialDirty}
             readOnly={!canEditSettings}
           />

--- a/src/components/routes/groups/Groups.tsx
+++ b/src/components/routes/groups/Groups.tsx
@@ -11,7 +11,6 @@ import { getApiErrorMessage } from "@/lib/apiErrors";
 import { PLAN_LANGUAGE } from "@/lib/constant";
 import { ROUTES } from "@/routes/paths";
 import { fetchGroups } from "./api/groupsApi";
-import { fetchTags } from "@/components/routes/tags/api/tagsApi";
 import { GroupListShell } from "./components/GroupPageShell";
 import GroupsTable from "./GroupsTable";
 import PendingGroupInvitationsBlock from "./components/PendingGroupInvitationsBlock";
@@ -21,7 +20,6 @@ const PAGE_SIZE = 10;
 const Groups = () => {
   const [search, setSearch] = useState("");
   const [language, setLanguage] = useState<string>("");
-  const [tagId, setTagId] = useState<string>("");
   const [currentPage, setCurrentPage] = useState(1);
   const [debouncedSearch] = useDebounce(search, 500);
 
@@ -30,23 +28,16 @@ const Groups = () => {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ["cms-groups", currentPage, debouncedSearch, language, tagId],
+    queryKey: ["cms-groups", currentPage, debouncedSearch, language],
     queryFn: () =>
       fetchGroups({
         page: currentPage,
         limit: PAGE_SIZE,
         search: debouncedSearch,
         language: language || undefined,
-        tag_id: tagId || undefined,
       }),
     refetchOnWindowFocus: false,
     retry: false,
-  });
-
-  const { data: tagsData } = useQuery({
-    queryKey: ["cms-tags-filter"],
-    queryFn: () => fetchTags(1, 100, ""),
-    refetchOnWindowFocus: false,
   });
 
   const totalPages = groupsData ? Math.ceil(groupsData.total / PAGE_SIZE) : 1;
@@ -84,26 +75,6 @@ const Groups = () => {
                 {PLAN_LANGUAGE.map((lang) => (
                   <Pecha.SelectItem key={lang.value} value={lang.value}>
                     {lang.label}
-                  </Pecha.SelectItem>
-                ))}
-              </Pecha.SelectContent>
-            </Pecha.Select>
-
-            <Pecha.Select
-              value={tagId || "all"}
-              onValueChange={(v) => {
-                setTagId(v === "all" ? "" : v);
-                setCurrentPage(1);
-              }}
-            >
-              <Pecha.SelectTrigger className="w-40 bg-white dark:bg-input/30">
-                <Pecha.SelectValue placeholder="Tag" />
-              </Pecha.SelectTrigger>
-              <Pecha.SelectContent>
-                <Pecha.SelectItem value="all">All tags</Pecha.SelectItem>
-                {(tagsData?.tags ?? []).map((tag) => (
-                  <Pecha.SelectItem key={tag.id} value={tag.id}>
-                    {tag.name}
                   </Pecha.SelectItem>
                 ))}
               </Pecha.SelectContent>

--- a/src/components/routes/groups/GroupsTable.tsx
+++ b/src/components/routes/groups/GroupsTable.tsx
@@ -1,7 +1,11 @@
 import { Pecha } from "@/components/ui/shadimport";
 import { useNavigate } from "react-router-dom";
 import { ROUTES } from "@/routes/paths";
-import { pickGroupTitle, type AuthorGroupListItem } from "./api/groupsApi";
+import {
+  pickGroupTitle,
+  resolveGroupAvatarUrl,
+  type AuthorGroupListItem,
+} from "./api/groupsApi";
 import GroupTitleWithAvatar from "./components/GroupTitleWithAvatar";
 
 interface GroupsTableProps {
@@ -43,6 +47,7 @@ const GroupsTable = ({ groups, isLoading }: GroupsTableProps) => {
               <Pecha.TableCell className="font-medium max-w-xs">
                 <GroupTitleWithAvatar
                   title={pickGroupTitle(group.metadata)}
+                  avatarUrl={resolveGroupAvatarUrl(group)}
                   size="sm"
                 />
               </Pecha.TableCell>

--- a/src/components/routes/groups/api/groupContentApi.ts
+++ b/src/components/routes/groups/api/groupContentApi.ts
@@ -1,7 +1,5 @@
-import {
-  fetchDashboardItems,
-  type DashboardTableRow,
-} from "@/components/routes/dashboard/dashboardApi";
+import { fetchDashboardItems } from "@/components/routes/dashboard/dashboardApi";
+import type { DashboardTableRow } from "@/components/routes/dashboard/dashboardTable";
 
 /** Group-scoped plan/series list (client-filtered by group_id after enrichment). */
 export async function fetchGroupContentRows(

--- a/src/components/routes/groups/api/groupContentApi.ts
+++ b/src/components/routes/groups/api/groupContentApi.ts
@@ -1,0 +1,18 @@
+import {
+  fetchDashboardItems,
+  type DashboardTableRow,
+} from "@/components/routes/dashboard/dashboardApi";
+
+/** Group-scoped plan/series list (client-filtered by group_id after enrichment). */
+export async function fetchGroupContentRows(
+  groupId: string,
+  options?: { pageSize?: number },
+): Promise<DashboardTableRow[]> {
+  const { rows } = await fetchDashboardItems({
+    tab: "all",
+    page: 1,
+    pageSize: options?.pageSize ?? 100,
+    group_id: groupId,
+  });
+  return rows;
+}

--- a/src/components/routes/groups/api/groupsApi.dashboardFilter.test.ts
+++ b/src/components/routes/groups/api/groupsApi.dashboardFilter.test.ts
@@ -12,7 +12,7 @@ describe("fetchAccessibleGroupsForDashboard", () => {
     vi.spyOn(Storage.prototype, "getItem").mockReturnValue("token");
   });
 
-  it("uses for_transfer for reviewers", async () => {
+  it("uses for_dashboard for reviewers (not for_transfer)", async () => {
     vi.mocked(axiosInstance.get).mockResolvedValueOnce({
       data: {
         groups: [
@@ -31,17 +31,58 @@ describe("fetchAccessibleGroupsForDashboard", () => {
       },
     });
 
-    await fetchAccessibleGroupsForDashboard("REVIEWER");
+    await fetchAccessibleGroupsForDashboard({
+      platform_role: "REVIEWER",
+      has_group: true,
+    });
 
     expect(axiosInstance.get).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        params: expect.objectContaining({ for_transfer: true }),
+        params: expect.objectContaining({ for_dashboard: true }),
+      }),
+    );
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.not.objectContaining({ for_transfer: true }),
       }),
     );
   });
 
-  it("omits for_transfer for creators", async () => {
+  it("uses for_dashboard for super admins", async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: {
+        groups: [
+          {
+            id: "g1",
+            slug: "g1",
+            is_public: true,
+            metadata: [{ title: "A", language: "EN" }],
+            tags: [],
+            follower_count: 0,
+          },
+        ],
+        skip: 0,
+        limit: 100,
+        total: 1,
+      },
+    });
+
+    await fetchAccessibleGroupsForDashboard({
+      platform_role: "SUPER_ADMIN",
+      has_group: true,
+    });
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ for_dashboard: true }),
+      }),
+    );
+  });
+
+  it("omits for_dashboard and for_transfer for creators", async () => {
     vi.mocked(axiosInstance.get).mockResolvedValueOnce({
       data: {
         groups: [],
@@ -51,12 +92,78 @@ describe("fetchAccessibleGroupsForDashboard", () => {
       },
     });
 
-    await fetchAccessibleGroupsForDashboard("CREATOR");
+    await fetchAccessibleGroupsForDashboard({
+      platform_role: "CREATOR",
+      has_group: true,
+    });
 
     expect(axiosInstance.get).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        params: expect.not.objectContaining({ for_transfer: true }),
+        params: expect.not.objectContaining({
+          for_transfer: true,
+          for_dashboard: true,
+        }),
+      }),
+    );
+  });
+
+  it("skips API for creators without a group", async () => {
+    const groups = await fetchAccessibleGroupsForDashboard({
+      platform_role: "CREATOR",
+      has_group: false,
+    });
+
+    expect(groups).toEqual([]);
+    expect(axiosInstance.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to plain list when for_dashboard returns no groups", async () => {
+    vi.mocked(axiosInstance.get)
+      .mockResolvedValueOnce({
+        data: { groups: [], skip: 0, limit: 100, total: 0 },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          groups: [
+            {
+              id: "g2",
+              slug: "g2",
+              is_public: true,
+              metadata: [{ title: "B", language: "EN" }],
+              tags: [],
+              follower_count: 0,
+            },
+          ],
+          skip: 0,
+          limit: 100,
+          total: 1,
+        },
+      });
+
+    const groups = await fetchAccessibleGroupsForDashboard({
+      platform_role: "REVIEWER",
+      has_group: true,
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].id).toBe("g2");
+    expect(axiosInstance.get).toHaveBeenCalledTimes(2);
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ for_dashboard: true }),
+      }),
+    );
+    expect(axiosInstance.get).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.not.objectContaining({
+          for_dashboard: true,
+          for_transfer: true,
+        }),
       }),
     );
   });

--- a/src/components/routes/groups/api/groupsApi.dashboardFilter.test.ts
+++ b/src/components/routes/groups/api/groupsApi.dashboardFilter.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axiosInstance from "@/config/axios-config";
+import { fetchAccessibleGroupsForDashboard } from "./groupsApi";
+
+vi.mock("@/config/axios-config", () => ({
+  default: { get: vi.fn() },
+}));
+
+describe("fetchAccessibleGroupsForDashboard", () => {
+  beforeEach(() => {
+    vi.mocked(axiosInstance.get).mockReset();
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue("token");
+  });
+
+  it("uses for_transfer for reviewers", async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: {
+        groups: [
+          {
+            id: "g1",
+            slug: "g1",
+            is_public: true,
+            metadata: [{ title: "A", language: "EN" }],
+            tags: [],
+            follower_count: 0,
+          },
+        ],
+        skip: 0,
+        limit: 100,
+        total: 1,
+      },
+    });
+
+    await fetchAccessibleGroupsForDashboard("REVIEWER");
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.objectContaining({ for_transfer: true }),
+      }),
+    );
+  });
+
+  it("omits for_transfer for creators", async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: {
+        groups: [],
+        skip: 0,
+        limit: 100,
+        total: 0,
+      },
+    });
+
+    await fetchAccessibleGroupsForDashboard("CREATOR");
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        params: expect.not.objectContaining({ for_transfer: true }),
+      }),
+    );
+  });
+});

--- a/src/components/routes/groups/api/groupsApi.transfer.test.ts
+++ b/src/components/routes/groups/api/groupsApi.transfer.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axiosInstance from "@/config/axios-config";
+import { fetchGroups, fetchGroupsForTransfer } from "./groupsApi";
+
+vi.mock("@/config/axios-config", () => ({
+  default: { get: vi.fn() },
+}));
+
+describe("fetchGroupsForTransfer", () => {
+  beforeEach(() => {
+    vi.mocked(axiosInstance.get).mockReset();
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue("token");
+  });
+
+  it("requests for_transfer=true with skip/limit pagination", async () => {
+    vi.mocked(axiosInstance.get)
+      .mockResolvedValueOnce({
+        data: {
+          groups: [
+            {
+              id: "g1",
+              slug: "g1",
+              is_public: true,
+              metadata: [],
+              tags: [],
+              follower_count: 0,
+            },
+          ],
+          skip: 0,
+          limit: 100,
+          total: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          groups: [
+            {
+              id: "g2",
+              slug: "g2",
+              is_public: true,
+              metadata: [],
+              tags: [],
+              follower_count: 0,
+            },
+          ],
+          skip: 100,
+          limit: 100,
+          total: 2,
+        },
+      });
+
+    const groups = await fetchGroupsForTransfer();
+
+    expect(groups).toHaveLength(2);
+    expect(axiosInstance.get).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(axiosInstance.get).mock.calls[0]?.[1]?.params,
+    ).toMatchObject({
+      skip: 0,
+      limit: 100,
+      for_transfer: true,
+    });
+    expect(
+      vi.mocked(axiosInstance.get).mock.calls[1]?.[1]?.params,
+    ).toMatchObject({
+      skip: 100,
+      limit: 100,
+      for_transfer: true,
+    });
+  });
+
+  it("excludes source group and passes search", async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: {
+        groups: [
+          {
+            id: "SOURCE",
+            slug: "s",
+            is_public: true,
+            metadata: [],
+            tags: [],
+            follower_count: 0,
+          },
+          {
+            id: "target",
+            slug: "t",
+            is_public: true,
+            metadata: [],
+            tags: [],
+            follower_count: 0,
+          },
+        ],
+        skip: 0,
+        limit: 100,
+        total: 2,
+      },
+    });
+
+    const groups = await fetchGroupsForTransfer({
+      excludeGroupId: "source",
+      search: "G3",
+    });
+
+    expect(groups.map((g) => g.id)).toEqual(["target"]);
+    expect(
+      vi.mocked(axiosInstance.get).mock.calls[0]?.[1]?.params,
+    ).toMatchObject({
+      search: "G3",
+      for_transfer: true,
+    });
+  });
+
+  it("does not send for_transfer on regular fetchGroups", async () => {
+    vi.mocked(axiosInstance.get).mockResolvedValueOnce({
+      data: { groups: [], skip: 0, limit: 10, total: 0 },
+    });
+
+    await fetchGroups({ page: 1, limit: 10 });
+
+    expect(
+      vi.mocked(axiosInstance.get).mock.calls[0]?.[1]?.params,
+    ).not.toHaveProperty("for_transfer");
+  });
+});

--- a/src/components/routes/groups/api/groupsApi.ts
+++ b/src/components/routes/groups/api/groupsApi.ts
@@ -1,5 +1,10 @@
 import axiosInstance from "@/config/axios-config";
 import type { LanguageCode } from "@/schema/SeriesSchema";
+import {
+  isReviewer,
+  isSuperAdmin,
+  type PlatformRole,
+} from "@/lib/platformAccess";
 
 export type AuthorGroupMemberRole = "OWNER" | "ADMIN" | "AUTHOR" | "VIEWER";
 
@@ -201,7 +206,11 @@ export interface FetchGroupsParams {
   search?: string;
   language?: string;
   tag_id?: string;
+  /** When true, lists all groups eligible as transfer targets (not only membership). */
+  for_transfer?: boolean;
 }
+
+export const TRANSFER_GROUPS_PAGE_LIMIT = 100;
 
 const getAuthHeaders = () => ({
   Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`,
@@ -213,23 +222,89 @@ export const fetchGroups = async ({
   search,
   language,
   tag_id,
+  for_transfer,
 }: FetchGroupsParams): Promise<AuthorGroupListResponse> => {
-  const skip = (page - 1) * limit;
+  const requestLimit = for_transfer
+    ? Math.min(Math.max(limit, 1), TRANSFER_GROUPS_PAGE_LIMIT)
+    : limit;
+  const skip = (page - 1) * requestLimit;
   const { data } = await axiosInstance.get<AuthorGroupListResponse>(
     `/api/v1/cms/author/groups`,
     {
       headers: getAuthHeaders(),
       params: {
         skip,
-        limit,
+        limit: requestLimit,
         ...(search?.trim() && { search: search.trim() }),
         ...(language && { language }),
         ...(tag_id && { tag_id }),
+        ...(for_transfer && { for_transfer: true }),
       },
     },
   );
   return data;
 };
+
+function groupIdsEqual(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+/** Loads all transfer-target groups (paginated), excluding the source group. */
+export const fetchGroupsForTransfer = async (options?: {
+  search?: string;
+  excludeGroupId?: string;
+}): Promise<AuthorGroupListItem[]> => {
+  const limit = TRANSFER_GROUPS_PAGE_LIMIT;
+  const collected: AuthorGroupListItem[] = [];
+  let page = 1;
+  let total = 0;
+
+  do {
+    const res = await fetchGroups({
+      page,
+      limit,
+      search: options?.search,
+      for_transfer: true,
+    });
+    total = res.total ?? 0;
+    const batch = res.groups ?? [];
+    collected.push(...batch);
+    if (batch.length === 0) break;
+    page += 1;
+  } while (collected.length < total);
+
+  const excludeId = options?.excludeGroupId?.trim();
+  if (!excludeId) return collected;
+  return collected.filter((g) => !groupIdsEqual(g.id, excludeId));
+};
+
+/** Groups the user may filter dashboard content by (membership vs staff-wide list). */
+export async function fetchAccessibleGroupsForDashboard(
+  platformRole?: PlatformRole | string,
+): Promise<AuthorGroupListItem[]> {
+  const staffWideList = isSuperAdmin(platformRole) || isReviewer(platformRole);
+  const limit = staffWideList ? TRANSFER_GROUPS_PAGE_LIMIT : 100;
+  const collected: AuthorGroupListItem[] = [];
+  let page = 1;
+  let total = 0;
+
+  do {
+    const res = await fetchGroups({
+      page,
+      limit,
+      for_transfer: staffWideList || undefined,
+    });
+    total = res.total ?? 0;
+    const batch = res.groups ?? [];
+    collected.push(...batch);
+    if (batch.length === 0) break;
+    page += 1;
+  } while (collected.length < total);
+
+  return collected.sort((a, b) =>
+    pickGroupTitle(a.metadata).localeCompare(pickGroupTitle(b.metadata)),
+  );
+}
 
 export const fetchGroup = async (
   groupId: string,

--- a/src/components/routes/groups/api/groupsApi.ts
+++ b/src/components/routes/groups/api/groupsApi.ts
@@ -1,10 +1,10 @@
 import axiosInstance from "@/config/axios-config";
 import type { LanguageCode } from "@/schema/SeriesSchema";
 import {
-  isReviewer,
-  isSuperAdmin,
+  usesStaffWideDashboardGroupList,
   type PlatformRole,
 } from "@/lib/platformAccess";
+import type { UserInfo } from "@/hooks/useUserInfo";
 
 export type AuthorGroupMemberRole = "OWNER" | "ADMIN" | "AUTHOR" | "VIEWER";
 
@@ -208,6 +208,8 @@ export interface FetchGroupsParams {
   tag_id?: string;
   /** When true, lists all groups eligible as transfer targets (not only membership). */
   for_transfer?: boolean;
+  /** When true, lists groups the user may filter dashboard content by (staff-wide read list). */
+  for_dashboard?: boolean;
 }
 
 export const TRANSFER_GROUPS_PAGE_LIMIT = 100;
@@ -223,6 +225,7 @@ export const fetchGroups = async ({
   language,
   tag_id,
   for_transfer,
+  for_dashboard,
 }: FetchGroupsParams): Promise<AuthorGroupListResponse> => {
   const requestLimit = for_transfer
     ? Math.min(Math.max(limit, 1), TRANSFER_GROUPS_PAGE_LIMIT)
@@ -239,6 +242,7 @@ export const fetchGroups = async ({
         ...(language && { language }),
         ...(tag_id && { tag_id }),
         ...(for_transfer && { for_transfer: true }),
+        ...(for_dashboard && { for_dashboard: true }),
       },
     },
   );
@@ -278,12 +282,15 @@ export const fetchGroupsForTransfer = async (options?: {
   return collected.filter((g) => !groupIdsEqual(g.id, excludeId));
 };
 
-/** Groups the user may filter dashboard content by (membership vs staff-wide list). */
-export async function fetchAccessibleGroupsForDashboard(
-  platformRole?: PlatformRole | string,
+export type DashboardGroupFilterUser = Pick<
+  UserInfo,
+  "platform_role" | "has_group"
+>;
+
+async function fetchAllGroupPages(
+  limit: number,
+  flags?: Pick<FetchGroupsParams, "for_dashboard" | "for_transfer">,
 ): Promise<AuthorGroupListItem[]> {
-  const staffWideList = isSuperAdmin(platformRole) || isReviewer(platformRole);
-  const limit = staffWideList ? TRANSFER_GROUPS_PAGE_LIMIT : 100;
   const collected: AuthorGroupListItem[] = [];
   let page = 1;
   let total = 0;
@@ -292,7 +299,7 @@ export async function fetchAccessibleGroupsForDashboard(
     const res = await fetchGroups({
       page,
       limit,
-      for_transfer: staffWideList || undefined,
+      ...flags,
     });
     total = res.total ?? 0;
     const batch = res.groups ?? [];
@@ -300,6 +307,35 @@ export async function fetchAccessibleGroupsForDashboard(
     if (batch.length === 0) break;
     page += 1;
   } while (collected.length < total);
+
+  return collected;
+}
+
+/** Groups the user may filter dashboard content by (membership vs staff-wide list). */
+export async function fetchAccessibleGroupsForDashboard(
+  user?: DashboardGroupFilterUser | null,
+): Promise<AuthorGroupListItem[]> {
+  const platformRole = user?.platform_role;
+  if (
+    platformRole &&
+    !usesStaffWideDashboardGroupList(platformRole) &&
+    user?.has_group === false
+  ) {
+    return [];
+  }
+
+  const staffWideList = usesStaffWideDashboardGroupList(platformRole);
+  const limit = staffWideList ? TRANSFER_GROUPS_PAGE_LIMIT : 100;
+
+  let collected = await fetchAllGroupPages(
+    limit,
+    staffWideList ? { for_dashboard: true } : undefined,
+  );
+
+  // Fallback when backend has not shipped for_dashboard yet.
+  if (staffWideList && collected.length === 0) {
+    collected = await fetchAllGroupPages(limit);
+  }
 
   return collected.sort((a, b) =>
     pickGroupTitle(a.metadata).localeCompare(pickGroupTitle(b.metadata)),

--- a/src/components/routes/groups/api/groupsApi.ts
+++ b/src/components/routes/groups/api/groupsApi.ts
@@ -1,9 +1,6 @@
 import axiosInstance from "@/config/axios-config";
 import type { LanguageCode } from "@/schema/SeriesSchema";
-import {
-  usesStaffWideDashboardGroupList,
-  type PlatformRole,
-} from "@/lib/platformAccess";
+import { usesStaffWideDashboardGroupList } from "@/lib/platformAccess";
 import type { UserInfo } from "@/hooks/useUserInfo";
 
 export type AuthorGroupMemberRole = "OWNER" | "ADMIN" | "AUTHOR" | "VIEWER";

--- a/src/components/routes/groups/components/GroupContentSection.tsx
+++ b/src/components/routes/groups/components/GroupContentSection.tsx
@@ -1,0 +1,81 @@
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { IoMdAdd } from "react-icons/io";
+import { Button } from "@/components/ui/atoms/button";
+import { fetchGroupContentRows } from "../api/groupContentApi";
+import { DashboardContentTable } from "@/components/routes/dashboard/DashboardContentTable";
+import { useTranslate } from "@tolgee/react";
+import { ROUTES } from "@/routes/paths";
+import { isReviewer } from "@/lib/platformAccess";
+import type { UserInfo } from "@/hooks/useUserInfo";
+import type { AuthorGroupMemberRole } from "../api/groupsApi";
+import { GroupDetailCard } from "./GroupSection";
+
+type GroupContentSectionProps = {
+  groupId: string;
+  userInfo?: UserInfo | null;
+  groupRole?: AuthorGroupMemberRole;
+  readOnlyPlatform?: boolean;
+};
+
+const GroupContentSection = ({
+  groupId,
+  userInfo,
+  groupRole,
+  readOnlyPlatform = false,
+}: GroupContentSectionProps) => {
+  const { t } = useTranslate();
+  const platformReadOnly =
+    readOnlyPlatform || isReviewer(userInfo?.platform_role);
+  const canCreate =
+    !platformReadOnly && groupRole != null && groupRole !== "VIEWER";
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["dashboard-items", "group", groupId],
+    queryFn: () => fetchGroupContentRows(groupId, { pageSize: 100 }),
+    refetchOnWindowFocus: false,
+  });
+
+  const rows = data ?? [];
+
+  return (
+    <GroupDetailCard title="Group content">
+      {canCreate ? (
+        <div className="mb-4 flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link to={ROUTES.groupPlanNew(groupId)}>
+              <IoMdAdd className="h-4 w-4" /> Add plan
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link to={ROUTES.groupSeriesNew(groupId)}>
+              <IoMdAdd className="h-4 w-4" /> Add series
+            </Link>
+          </Button>
+        </div>
+      ) : null}
+
+      {isError ? (
+        <p className="text-sm text-destructive">{String(error)}</p>
+      ) : rows.length === 0 && !isLoading ? (
+        <p className="text-sm text-muted-foreground">
+          No plans or series in this group yet.
+          {canCreate ? " Use the buttons above to add content." : null}
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <DashboardContentTable
+            rows={rows}
+            t={t}
+            handleFeatured={() => {}}
+            platformRole={userInfo?.platform_role}
+            groupRolesByGroupId={new Map([[groupId, groupRole]])}
+            userInfo={userInfo}
+          />
+        </div>
+      )}
+    </GroupDetailCard>
+  );
+};
+
+export default GroupContentSection;

--- a/src/components/routes/groups/components/GroupFormAssociationsPanel.tsx
+++ b/src/components/routes/groups/components/GroupFormAssociationsPanel.tsx
@@ -1,11 +1,6 @@
 import PlanTagSearchInput from "@/components/routes/create-plan/PlanTagSearchInput";
 import type { TagSummaryDTO } from "../api/groupsApi";
-import {
-  mapGroupTagsToPlanTagSummaries,
-  searchPlansForPicker,
-  searchSeriesForPicker,
-} from "../api/groupPickerApi";
-import FkMultiSearchSelector, { type FkOption } from "./FkMultiSearchSelector";
+import { mapGroupTagsToPlanTagSummaries } from "../api/groupPickerApi";
 import { GroupEditableSection } from "./GroupSection";
 import GroupSocialLinksEditor from "./GroupSocialLinksEditor";
 import type { GroupSocialLinkDTO } from "../api/groupsApi";
@@ -14,23 +9,13 @@ type GroupFormAssociationsPanelProps = {
   tagIds: string[];
   onTagIdsChange: (ids: string[]) => void;
   initialTags: TagSummaryDTO[];
-  selectedPlans: FkOption[];
-  onPlansChange: (plans: FkOption[]) => void;
-  selectedSeries: FkOption[];
-  onSeriesChange: (series: FkOption[]) => void;
   socialLinks: GroupSocialLinkDTO[];
   onSocialLinksChange: (links: GroupSocialLinkDTO[]) => void;
   onSaveTags: () => void;
-  onSavePlans: () => void;
-  onSaveSeries: () => void;
   onSaveSocial: () => void;
   tagsSaving: boolean;
-  plansSaving: boolean;
-  seriesSaving: boolean;
   socialSaving: boolean;
   tagsSaveDisabled?: boolean;
-  plansSaveDisabled?: boolean;
-  seriesSaveDisabled?: boolean;
   socialSaveDisabled?: boolean;
   readOnly?: boolean;
 };
@@ -39,23 +24,13 @@ const GroupFormAssociationsPanel = ({
   tagIds,
   onTagIdsChange,
   initialTags,
-  selectedPlans,
-  onPlansChange,
-  selectedSeries,
-  onSeriesChange,
   socialLinks,
   onSocialLinksChange,
   onSaveTags,
-  onSavePlans,
-  onSaveSeries,
   onSaveSocial,
   tagsSaving,
-  plansSaving,
-  seriesSaving,
   socialSaving,
   tagsSaveDisabled = false,
-  plansSaveDisabled = false,
-  seriesSaveDisabled = false,
   socialSaveDisabled = false,
   readOnly = false,
 }: GroupFormAssociationsPanelProps) => (
@@ -74,46 +49,6 @@ const GroupFormAssociationsPanel = ({
         onChange={onTagIdsChange}
         hideLabel
         initialTags={mapGroupTagsToPlanTagSummaries(initialTags)}
-      />
-    </GroupEditableSection>
-
-    <GroupEditableSection
-      title="Linked plans"
-      onSave={onSavePlans}
-      isSaving={plansSaving}
-      saveDisabled={plansSaveDisabled}
-      saveLabel="Save plans"
-      savingLabel="Saving…"
-      readOnly={readOnly}
-    >
-      <FkMultiSearchSelector
-        value={selectedPlans}
-        onChange={onPlansChange}
-        searchFn={searchPlansForPicker}
-        queryKeyPrefix="group-plan-search"
-        hideLabel
-        searchPlaceholder="Search plans to link…"
-        emptyMessage="No plans linked — search to add plans."
-      />
-    </GroupEditableSection>
-
-    <GroupEditableSection
-      title="Linked series"
-      onSave={onSaveSeries}
-      isSaving={seriesSaving}
-      saveDisabled={seriesSaveDisabled}
-      saveLabel="Save series"
-      savingLabel="Saving…"
-      readOnly={readOnly}
-    >
-      <FkMultiSearchSelector
-        value={selectedSeries}
-        onChange={onSeriesChange}
-        searchFn={searchSeriesForPicker}
-        queryKeyPrefix="group-series-search"
-        hideLabel
-        searchPlaceholder="Search series to link…"
-        emptyMessage="No series linked — search to add series."
       />
     </GroupEditableSection>
 

--- a/src/components/routes/groups/components/GroupInvitesAdminSection.tsx
+++ b/src/components/routes/groups/components/GroupInvitesAdminSection.tsx
@@ -4,6 +4,8 @@ import { toast } from "sonner";
 import { Pecha } from "@/components/ui/shadimport";
 import { Button } from "@/components/ui/atoms/button";
 import { getApiErrorMessage } from "@/lib/apiErrors";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { shouldShowCmsActionsColumn } from "@/lib/platformAccess";
 import {
   createGroupInvite,
   fetchGroupInvites,
@@ -42,6 +44,9 @@ const GroupInvitesAdminSection = ({
   groupId,
   myRole,
 }: GroupInvitesAdminSectionProps) => {
+  const { data: userInfo } = useUserInfo();
+  const showActionsColumn = shouldShowCmsActionsColumn(userInfo?.platform_role);
+  const inviteTableColSpan = showActionsColumn ? 6 : 5;
   const queryClient = useQueryClient();
   const [inviteOpen, setInviteOpen] = useState(false);
   const [targetEmail, setTargetEmail] = useState("");
@@ -145,19 +150,29 @@ const GroupInvitesAdminSection = ({
               <Pecha.TableHead>Status</Pecha.TableHead>
               <Pecha.TableHead>Expires</Pecha.TableHead>
               <Pecha.TableHead>Invited by</Pecha.TableHead>
-              <Pecha.TableHead className="text-right">Actions</Pecha.TableHead>
+              {showActionsColumn ? (
+                <Pecha.TableHead className="text-right">
+                  Actions
+                </Pecha.TableHead>
+              ) : null}
             </Pecha.TableRow>
           </Pecha.TableHeader>
           <Pecha.TableBody>
             {isLoading ? (
               <Pecha.TableRow>
-                <Pecha.TableCell colSpan={6} className="text-muted-foreground">
+                <Pecha.TableCell
+                  colSpan={inviteTableColSpan}
+                  className="text-muted-foreground"
+                >
                   Loading invitations…
                 </Pecha.TableCell>
               </Pecha.TableRow>
             ) : invites.length === 0 ? (
               <Pecha.TableRow>
-                <Pecha.TableCell colSpan={6} className="text-muted-foreground">
+                <Pecha.TableCell
+                  colSpan={inviteTableColSpan}
+                  className="text-muted-foreground"
+                >
                   No invitations found
                 </Pecha.TableCell>
               </Pecha.TableRow>
@@ -183,21 +198,23 @@ const GroupInvitesAdminSection = ({
                         : inviter.email;
                     })()}
                   </Pecha.TableCell>
-                  <Pecha.TableCell className="text-right">
-                    {invite.status === "PENDING" &&
-                      canRevokeInvite(myRole, invite) && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="text-red-600 hover:text-red-700"
-                          disabled={revokeMutation.isPending}
-                          onClick={() => revokeMutation.mutate(invite.id)}
-                        >
-                          Revoke
-                        </Button>
-                      )}
-                  </Pecha.TableCell>
+                  {showActionsColumn ? (
+                    <Pecha.TableCell className="text-right">
+                      {invite.status === "PENDING" &&
+                        canRevokeInvite(myRole, invite) && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-red-600 hover:text-red-700"
+                            disabled={revokeMutation.isPending}
+                            onClick={() => revokeMutation.mutate(invite.id)}
+                          >
+                            Revoke
+                          </Button>
+                        )}
+                    </Pecha.TableCell>
+                  ) : null}
                 </Pecha.TableRow>
               ))
             )}

--- a/src/components/routes/groups/components/GroupMembersPanel.tsx
+++ b/src/components/routes/groups/components/GroupMembersPanel.tsx
@@ -6,6 +6,7 @@ import { Pecha } from "@/components/ui/shadimport";
 import { Button } from "@/components/ui/atoms/button";
 import { getApiErrorMessage } from "@/lib/apiErrors";
 import { useUserInfo } from "@/hooks/useUserInfo";
+import { isReviewer, shouldShowCmsActionsColumn } from "@/lib/platformAccess";
 import { ROUTES } from "@/routes/paths";
 import {
   removeGroupMember,
@@ -40,16 +41,20 @@ const GroupMembersPanel = ({ groupId, members }: GroupMembersPanelProps) => {
     ? {
         id: userInfo.id,
         email: userInfo.email,
-        is_admin: userInfo.is_admin,
+        platform_role: userInfo.platform_role,
       }
     : undefined;
   const myRole = getEffectiveGroupRole(members, actor);
+  const platformReadOnly = isReviewer(userInfo?.platform_role);
+  const showActionsColumn = shouldShowCmsActionsColumn(userInfo?.platform_role);
   const [removeTarget, setRemoveTarget] = useState<AuthorGroupMemberDTO | null>(
     null,
   );
   const [transferOpen, setTransferOpen] = useState(false);
 
-  const showTransferOwnership = canTransferOwnership(members, actor);
+  const showTransferOwnership =
+    !platformReadOnly && canTransferOwnership(members, actor);
+  const showInvitesSection = !platformReadOnly && canManageGroupInvites(myRole);
   const transferCandidates = transferOwnershipCandidates(members, actor);
 
   const leavingSelf =
@@ -117,9 +122,11 @@ const GroupMembersPanel = ({ groupId, members }: GroupMembersPanelProps) => {
                 <Pecha.TableHead>Name</Pecha.TableHead>
                 <Pecha.TableHead>Email</Pecha.TableHead>
                 <Pecha.TableHead>Role</Pecha.TableHead>
-                <Pecha.TableHead className="text-right">
-                  Actions
-                </Pecha.TableHead>
+                {showActionsColumn ? (
+                  <Pecha.TableHead className="text-right">
+                    Actions
+                  </Pecha.TableHead>
+                ) : null}
               </Pecha.TableRow>
             </Pecha.TableHeader>
             <Pecha.TableBody>
@@ -147,7 +154,7 @@ const GroupMembersPanel = ({ groupId, members }: GroupMembersPanelProps) => {
                       {member.email}
                     </Pecha.TableCell>
                     <Pecha.TableCell>
-                      {assignableRoles ? (
+                      {assignableRoles && !platformReadOnly ? (
                         <Pecha.Select
                           value={displayRole}
                           onValueChange={(role) =>
@@ -173,19 +180,21 @@ const GroupMembersPanel = ({ groupId, members }: GroupMembersPanelProps) => {
                         <span className="text-sm">{displayRole}</span>
                       )}
                     </Pecha.TableCell>
-                    <Pecha.TableCell className="text-right">
-                      {showRemoval && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="text-red-600 hover:text-red-700"
-                          onClick={() => setRemoveTarget(member)}
-                        >
-                          {isSelf ? "Leave" : "Remove"}
-                        </Button>
-                      )}
-                    </Pecha.TableCell>
+                    {showActionsColumn ? (
+                      <Pecha.TableCell className="text-right">
+                        {showRemoval && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-red-600 hover:text-red-700"
+                            onClick={() => setRemoveTarget(member)}
+                          >
+                            {isSelf ? "Leave" : "Remove"}
+                          </Button>
+                        )}
+                      </Pecha.TableCell>
+                    ) : null}
                   </Pecha.TableRow>
                 );
               })}
@@ -194,9 +203,9 @@ const GroupMembersPanel = ({ groupId, members }: GroupMembersPanelProps) => {
         </div>
       </div>
 
-      {canManageGroupInvites(myRole) && (
+      {showInvitesSection ? (
         <GroupInvitesAdminSection groupId={groupId} myRole={myRole} />
-      )}
+      ) : null}
 
       {showTransferOwnership && (
         <GroupTransferOwnershipDialog

--- a/src/components/routes/groups/components/GroupTransfersSection.tsx
+++ b/src/components/routes/groups/components/GroupTransfersSection.tsx
@@ -1,0 +1,389 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/atoms/button";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import {
+  acceptTransferRequest,
+  fetchIncomingTransferRequests,
+  fetchOutgoingTransferRequests,
+  filterIncomingForGroup,
+  filterOutgoingForGroup,
+  isTransferRequestExpired,
+  rejectTransferRequest,
+  revokeTransferRequest,
+  type ContentTransferRequestDTO,
+} from "@/components/routes/content-transfer/api/transferApi";
+import { formatDistanceToNow } from "date-fns";
+import { GroupDetailCard } from "./GroupSection";
+
+type GroupTransfersSectionProps = {
+  groupId: string;
+  canManageIncoming: boolean;
+  canManageOutgoing: boolean;
+  alwaysVisible?: boolean;
+};
+
+function TransferRow({
+  req,
+  actions,
+}: {
+  req: ContentTransferRequestDTO;
+  actions: React.ReactNode;
+}) {
+  const expired = isTransferRequestExpired(req);
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-2 border-b py-2 text-sm last:border-0">
+      <div>
+        <span className="font-medium capitalize">{req.content_type}</span>
+        {req.content_title ? `: ${req.content_title}` : null}
+        <span className="text-muted-foreground">
+          {" "}
+          · {req.status}
+          {req.source_group_title ||
+          req.target_group_title ||
+          req.source_group_id ||
+          req.target_group_id ? (
+            <>
+              {" "}
+              · {(req.source_group_title ?? req.source_group_id) || "—"} →{" "}
+              {(req.target_group_title ?? req.target_group_id) || "—"}
+            </>
+          ) : null}
+        </span>
+        {req.status === "PENDING" && req.expires_at && !expired ? (
+          <div className="mt-1 text-xs text-muted-foreground">
+            {formatDistanceToNow(new Date(req.expires_at))} left
+          </div>
+        ) : null}
+        {expired ? (
+          <div className="mt-1 text-xs text-muted-foreground">Expired</div>
+        ) : null}
+      </div>
+      <div className="flex gap-2">{expired ? null : actions}</div>
+    </li>
+  );
+}
+
+const GroupTransfersSection = ({
+  groupId,
+  canManageIncoming,
+  canManageOutgoing,
+  alwaysVisible = false,
+}: GroupTransfersSectionProps) => {
+  const queryClient = useQueryClient();
+
+  const {
+    data: incomingScoped,
+    isLoading: isIncomingScopedLoading,
+    isError: isIncomingScopedError,
+    error: incomingScopedError,
+  } = useQuery({
+    queryKey: ["transfer-requests", "incoming", "scoped", groupId],
+    queryFn: () => fetchIncomingTransferRequests(groupId),
+    refetchOnWindowFocus: true,
+  });
+
+  const {
+    data: incomingAll,
+    isLoading: isIncomingAllLoading,
+    isError: isIncomingAllError,
+    error: incomingAllError,
+  } = useQuery({
+    queryKey: ["transfer-requests", "incoming", "all"],
+    queryFn: () => fetchIncomingTransferRequests(),
+    refetchOnWindowFocus: true,
+  });
+
+  const {
+    data: outgoingScoped,
+    isLoading: isOutgoingScopedLoading,
+    isError: isOutgoingScopedError,
+    error: outgoingScopedError,
+  } = useQuery({
+    queryKey: ["transfer-requests", "outgoing", "scoped", groupId],
+    queryFn: () => fetchOutgoingTransferRequests(groupId),
+    refetchOnWindowFocus: true,
+  });
+
+  const {
+    data: outgoingAll,
+    isLoading: isOutgoingAllLoading,
+    isError: isOutgoingAllError,
+    error: outgoingAllError,
+  } = useQuery({
+    queryKey: ["transfer-requests", "outgoing", "all"],
+    queryFn: () => fetchOutgoingTransferRequests(),
+    refetchOnWindowFocus: true,
+  });
+
+  const incomingForGroup = useMemo(() => {
+    const all = incomingAll?.requests ?? [];
+    const scoped = incomingScoped?.requests ?? [];
+    const filtered = filterIncomingForGroup(all, groupId);
+    if (filtered.length > 0) return filtered;
+    if (scoped.length > 0) return scoped;
+    // API returned rows but group ids missing/wrong in JSON — still show them.
+    if (all.length > 0) return all;
+    return filterIncomingForGroup(scoped, groupId);
+  }, [incomingScoped?.requests, incomingAll?.requests, groupId]);
+
+  const outgoingForGroup = useMemo(() => {
+    const all = outgoingAll?.requests ?? [];
+    const scoped = outgoingScoped?.requests ?? [];
+    const filtered = filterOutgoingForGroup(all, groupId);
+    if (filtered.length > 0) return filtered;
+    if (scoped.length > 0) return scoped;
+    if (all.length > 0) return all;
+    return filterOutgoingForGroup(scoped, groupId);
+  }, [outgoingScoped?.requests, outgoingAll?.requests, groupId]);
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["transfer-requests"] });
+    queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
+    queryClient.invalidateQueries({ queryKey: ["cms-group", groupId] });
+    queryClient.invalidateQueries({ queryKey: ["cms-notifications"] });
+  };
+
+  const acceptMutation = useMutation({
+    mutationFn: acceptTransferRequest,
+    onSuccess: () => {
+      toast.success("Transfer accepted");
+      invalidate();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: rejectTransferRequest,
+    onSuccess: () => {
+      toast.success("Transfer rejected");
+      invalidate();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: revokeTransferRequest,
+    onSuccess: () => {
+      toast.success("Transfer revoked");
+      invalidate();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const isLoading =
+    isIncomingScopedLoading ||
+    isIncomingAllLoading ||
+    isOutgoingScopedLoading ||
+    isOutgoingAllLoading;
+
+  const hasRequests =
+    incomingForGroup.length > 0 || outgoingForGroup.length > 0;
+
+  const hasApiData =
+    (incomingAll?.requests?.length ?? 0) > 0 ||
+    (outgoingAll?.requests?.length ?? 0) > 0;
+
+  const showCard = alwaysVisible || hasRequests || isLoading || hasApiData;
+
+  if (!showCard) {
+    return null;
+  }
+
+  const incomingError = isIncomingScopedError
+    ? incomingScopedError
+    : isIncomingAllError
+      ? incomingAllError
+      : null;
+
+  const outgoingError = isOutgoingScopedError
+    ? outgoingScopedError
+    : isOutgoingAllError
+      ? outgoingAllError
+      : null;
+
+  return (
+    <GroupDetailCard title="Content transfers">
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Loading transfers…</p>
+      ) : null}
+
+      {incomingError ? (
+        <p className="text-sm text-destructive mb-3">
+          {getApiErrorMessage(
+            incomingError,
+            "Could not load incoming transfers",
+          )}
+        </p>
+      ) : null}
+
+      {outgoingError ? (
+        <p className="text-sm text-destructive mb-3">
+          {getApiErrorMessage(
+            outgoingError,
+            "Could not load outgoing transfers",
+          )}
+        </p>
+      ) : null}
+
+      {!isLoading && !hasRequests && hasApiData ? (
+        <>
+          <p className="text-sm text-amber-700 dark:text-amber-400 mb-3">
+            Transfer requests exist but could not be matched to this group ID.
+            Showing all incoming/outgoing for your account — accept from the
+            target group or use notifications.
+          </p>
+          {(incomingAll?.requests?.length ?? 0) > 0 ? (
+            <div className="mb-4">
+              <p className="text-xs font-semibold uppercase text-muted-foreground mb-2">
+                All incoming (account)
+              </p>
+              <ul>
+                {incomingAll!.requests.map((req) => (
+                  <TransferRow
+                    key={req.id}
+                    req={req}
+                    actions={
+                      canManageIncoming && req.status === "PENDING" ? (
+                        <>
+                          <Button
+                            size="sm"
+                            variant="default"
+                            disabled={
+                              acceptMutation.isPending ||
+                              rejectMutation.isPending
+                            }
+                            onClick={() => acceptMutation.mutate(req.id)}
+                          >
+                            Accept
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={
+                              acceptMutation.isPending ||
+                              rejectMutation.isPending
+                            }
+                            onClick={() => rejectMutation.mutate(req.id)}
+                          >
+                            Reject
+                          </Button>
+                        </>
+                      ) : null
+                    }
+                  />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {(outgoingAll?.requests?.length ?? 0) > 0 ? (
+            <div>
+              <p className="text-xs font-semibold uppercase text-muted-foreground mb-2">
+                All outgoing (account)
+              </p>
+              <ul>
+                {outgoingAll!.requests.map((req) => (
+                  <TransferRow
+                    key={req.id}
+                    req={req}
+                    actions={
+                      canManageOutgoing && req.status === "PENDING" ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={revokeMutation.isPending}
+                          onClick={() => revokeMutation.mutate(req.id)}
+                        >
+                          Revoke
+                        </Button>
+                      ) : null
+                    }
+                  />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      {!isLoading && !hasRequests && !hasApiData ? (
+        <p className="text-sm text-muted-foreground">
+          No transfer requests for this group right now.
+        </p>
+      ) : null}
+
+      {incomingForGroup.length > 0 ? (
+        <div className="mb-4">
+          <p className="text-xs font-semibold uppercase text-muted-foreground mb-2">
+            Incoming
+          </p>
+          <ul>
+            {incomingForGroup.map((req) => (
+              <TransferRow
+                key={req.id}
+                req={req}
+                actions={
+                  canManageIncoming && req.status === "PENDING" ? (
+                    <>
+                      <Button
+                        size="sm"
+                        variant="default"
+                        disabled={
+                          acceptMutation.isPending || rejectMutation.isPending
+                        }
+                        onClick={() => acceptMutation.mutate(req.id)}
+                      >
+                        Accept
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={
+                          acceptMutation.isPending || rejectMutation.isPending
+                        }
+                        onClick={() => rejectMutation.mutate(req.id)}
+                      >
+                        Reject
+                      </Button>
+                    </>
+                  ) : null
+                }
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {outgoingForGroup.length > 0 ? (
+        <div>
+          <p className="text-xs font-semibold uppercase text-muted-foreground mb-2">
+            Outgoing
+          </p>
+          <ul>
+            {outgoingForGroup.map((req) => (
+              <TransferRow
+                key={req.id}
+                req={req}
+                actions={
+                  canManageOutgoing && req.status === "PENDING" ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={revokeMutation.isPending}
+                      onClick={() => revokeMutation.mutate(req.id)}
+                    >
+                      Revoke
+                    </Button>
+                  ) : null
+                }
+              />
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </GroupDetailCard>
+  );
+};
+
+export default GroupTransfersSection;

--- a/src/components/routes/groups/lib/groupPermissions.ts
+++ b/src/components/routes/groups/lib/groupPermissions.ts
@@ -1,3 +1,5 @@
+import type { PlatformRole } from "@/lib/platformAccess";
+import { isSuperAdmin } from "@/lib/platformAccess";
 import {
   isGroupInviteExpired,
   type AuthorGroupMemberDTO,
@@ -24,7 +26,7 @@ const MEMBER_MANAGEMENT_ROLES: AuthorGroupMemberRole[] = ["OWNER", "ADMIN"];
 export type GroupActor = {
   id?: string;
   email?: string;
-  is_admin?: boolean;
+  platform_role?: PlatformRole;
 };
 
 /** Legacy DB rows may still surface as ADMIN after EDITOR migration. */
@@ -44,19 +46,28 @@ function findMemberByEmail(
 
 export function getCurrentUserGroupRole(
   members: AuthorGroupMemberDTO[],
-  userEmail: string | undefined,
+  user: GroupActor | string | undefined,
 ): AuthorGroupMemberRole | undefined {
-  const member = findMemberByEmail(members, userEmail);
+  if (!user) return undefined;
+  if (typeof user === "string") {
+    const member = findMemberByEmail(members, user);
+    return member ? normalizeMemberRole(member.role) : undefined;
+  }
+  if (user.id) {
+    const byId = members.find((m) => m.author_id === user.id);
+    if (byId) return normalizeMemberRole(byId.role);
+  }
+  const member = findMemberByEmail(members, user.email);
   return member ? normalizeMemberRole(member.role) : undefined;
 }
 
-/** Platform admin is treated as OWNER for all group permission checks. */
+/** SUPER_ADMIN bypass for CMS management actions (not ownership transfer). */
 export function getEffectiveGroupRole(
   members: AuthorGroupMemberDTO[],
   user: GroupActor | undefined,
 ): AuthorGroupMemberRole | undefined {
-  if (user?.is_admin) return "OWNER";
-  return getCurrentUserGroupRole(members, user?.email);
+  if (isSuperAdmin(user?.platform_role)) return "OWNER";
+  return getCurrentUserGroupRole(members, user);
 }
 
 export function canEditGroupSettings(
@@ -98,12 +109,12 @@ export function roleChangeOptions(
   return ["AUTHOR", "VIEWER"];
 }
 
-/** True only for the actual group OWNER row (platform is_admin does not apply). */
+/** True only for the actual group OWNER row (platform SUPER_ADMIN bypass does not apply). */
 export function canTransferOwnership(
   members: AuthorGroupMemberDTO[],
   user: GroupActor | undefined,
 ): boolean {
-  return getCurrentUserGroupRole(members, user?.email) === "OWNER";
+  return getCurrentUserGroupRole(members, user) === "OWNER";
 }
 
 export function transferOwnershipCandidates(

--- a/src/components/routes/notifications/api/notificationsApi.ts
+++ b/src/components/routes/notifications/api/notificationsApi.ts
@@ -1,6 +1,9 @@
 import axiosInstance from "@/config/axios-config";
 
-export type NotificationCategory = "group_invite" | (string & {});
+export type NotificationCategory =
+  | "group_invite"
+  | "content_transfer_incoming"
+  | (string & {});
 
 export interface NotificationDTO {
   id: string;
@@ -8,9 +11,72 @@ export interface NotificationDTO {
   description?: string | null;
   category: NotificationCategory;
   reference_id?: string | null;
+  /** Target group for content_transfer_incoming (when provided by API). */
+  target_group_id?: string | null;
+  group_id?: string | null;
   is_read: boolean;
   read_at?: string | null;
   created_at: string;
+}
+
+function normalizeNotification(raw: unknown): NotificationDTO | null {
+  if (!raw || typeof raw !== "object") return null;
+  const n = raw as Record<string, unknown>;
+  const id = typeof n.id === "string" ? n.id : undefined;
+  if (!id) return null;
+  const metadata =
+    n.metadata && typeof n.metadata === "object"
+      ? (n.metadata as Record<string, unknown>)
+      : null;
+  const targetFromMeta =
+    typeof metadata?.target_group_id === "string"
+      ? metadata.target_group_id
+      : typeof metadata?.group_id === "string"
+        ? metadata.group_id
+        : undefined;
+
+  return {
+    id,
+    title: typeof n.title === "string" ? n.title : "Notification",
+    description: typeof n.description === "string" ? n.description : null,
+    category: (typeof n.category === "string"
+      ? n.category
+      : "group_invite") as NotificationCategory,
+    reference_id: typeof n.reference_id === "string" ? n.reference_id : null,
+    target_group_id:
+      (typeof n.target_group_id === "string" ? n.target_group_id : null) ??
+      (typeof n.group_id === "string" ? n.group_id : null) ??
+      targetFromMeta ??
+      null,
+    group_id: typeof n.group_id === "string" ? n.group_id : null,
+    is_read: Boolean(n.is_read),
+    read_at: typeof n.read_at === "string" ? n.read_at : null,
+    created_at:
+      typeof n.created_at === "string"
+        ? n.created_at
+        : new Date().toISOString(),
+  };
+}
+
+function normalizeNotificationList(data: unknown): NotificationListResponse {
+  if (!data || typeof data !== "object") {
+    return { notifications: [], skip: 0, limit: 0, total: 0 };
+  }
+  const root = data as Record<string, unknown>;
+  const list = Array.isArray(root.notifications)
+    ? root.notifications
+    : Array.isArray(root.items)
+      ? root.items
+      : [];
+  const notifications = list
+    .map(normalizeNotification)
+    .filter((n): n is NotificationDTO => n != null);
+  return {
+    notifications,
+    skip: typeof root.skip === "number" ? root.skip : 0,
+    limit: typeof root.limit === "number" ? root.limit : notifications.length,
+    total: typeof root.total === "number" ? root.total : notifications.length,
+  };
 }
 
 export interface NotificationListResponse {
@@ -33,18 +99,15 @@ const getAuthHeaders = () => ({
 export const fetchNotifications = async (
   params: FetchNotificationsParams = {},
 ): Promise<NotificationListResponse> => {
-  const { data } = await axiosInstance.get<NotificationListResponse>(
-    `/api/v1/cms/notifications`,
-    {
-      headers: getAuthHeaders(),
-      params: {
-        unread_only: params.unread_only ?? false,
-        skip: params.skip ?? 0,
-        limit: params.limit ?? 20,
-      },
+  const { data } = await axiosInstance.get(`/api/v1/cms/notifications`, {
+    headers: getAuthHeaders(),
+    params: {
+      unread_only: params.unread_only ?? false,
+      skip: params.skip ?? 0,
+      limit: params.limit ?? 20,
     },
-  );
-  return data;
+  });
+  return normalizeNotificationList(data);
 };
 
 export const markNotificationRead = async (
@@ -63,3 +126,19 @@ export const isGroupInviteNotification = (
 ): boolean =>
   notification.category === "group_invite" &&
   Boolean(notification.reference_id);
+
+export const isContentTransferNotification = (
+  notification: NotificationDTO,
+): boolean =>
+  notification.category === "content_transfer_incoming" &&
+  Boolean(notification.reference_id);
+
+export function getTransferNotificationTargetGroupId(
+  notification: NotificationDTO,
+): string | undefined {
+  return (
+    notification.target_group_id?.trim() ||
+    notification.group_id?.trim() ||
+    undefined
+  );
+}

--- a/src/components/routes/profile/Profile.test.tsx
+++ b/src/components/routes/profile/Profile.test.tsx
@@ -67,14 +67,10 @@ describe("Profile Component", () => {
     expect(screen.getByText("Edit")).toBeInTheDocument();
   });
 
-  it("fetches current user info from authors info endpoint", async () => {
-    const { default: axiosInstance } = await import("@/config/axios-config");
-    vi.mocked(axiosInstance.get).mockResolvedValue({
-      data: mockUserInfo,
-    });
-    renderWithProviders(<Profile />);
+  it("shows user info from shared userInfo query", async () => {
+    renderWithProviders(<Profile />, mockUserInfo);
     await waitFor(() => {
-      expect(axiosInstance.get).toHaveBeenCalledWith("/api/v1/authors/info");
+      expect(screen.getByText("Tenzin la")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/routes/series-details/SeriesDetailsPage.test.tsx
+++ b/src/components/routes/series-details/SeriesDetailsPage.test.tsx
@@ -15,6 +15,7 @@ vi.mock(
 
 const seriesFixture = {
   id: "series-1",
+  group_id: "group-1",
   metadata: [{ id: "m1", title: "Abhidhamma in a year", language: "EN" }],
   featured: false,
   status: "DRAFT",
@@ -67,9 +68,14 @@ describe("SeriesDetailsPage", () => {
 
   it("navigates to plan new with series and active language in location state", async () => {
     function PlanNewStateProbe() {
-      const { state } = useLocation();
+      const { state, pathname } = useLocation();
       return (
-        <div data-testid="plan-new-location-state">{JSON.stringify(state)}</div>
+        <>
+          <div data-testid="plan-new-location-state">
+            {JSON.stringify(state)}
+          </div>
+          <div data-testid="plan-new-pathname">{pathname}</div>
+        </>
       );
     }
 
@@ -85,7 +91,10 @@ describe("SeriesDetailsPage", () => {
         <MemoryRouter initialEntries={["/series/series-1"]}>
           <Routes>
             <Route path="/series/:seriesId" element={<SeriesDetailsPage />} />
-            <Route path="/plan/new" element={<PlanNewStateProbe />} />
+            <Route
+              path="/groups/:groupId/plan/new"
+              element={<PlanNewStateProbe />}
+            />
           </Routes>
         </MemoryRouter>
       </QueryClientProvider>,
@@ -102,6 +111,9 @@ describe("SeriesDetailsPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("plan-new-location-state")).toHaveTextContent(
         JSON.stringify({ seriesId: "series-1", language: "ZH" }),
+      );
+      expect(screen.getByTestId("plan-new-pathname")).toHaveTextContent(
+        "/groups/group-1/plan/new",
       );
     });
   });

--- a/src/components/routes/series-details/SeriesDetailsPage.tsx
+++ b/src/components/routes/series-details/SeriesDetailsPage.tsx
@@ -26,6 +26,8 @@ import {
   seriesPlansToRows,
 } from "./seriesDetailsMappers";
 import type { PlansByLanguage } from "./seriesDetailsTypes";
+import { useGroupContentPermissions } from "@/hooks/useGroupContentPermissions";
+import { DropdownButton } from "@/components/ui/molecules/dropdown-button/DropdownButton";
 
 const togglePlanFeatured = async (planId: string) => {
   const { data } = await axiosInstance.patch(
@@ -78,6 +80,21 @@ const SeriesDetailsPage = () => {
     [activePlans],
   );
 
+  const seriesStatus = seriesData?.status ?? "DRAFT";
+  const {
+    platformRole,
+    groupRole,
+    platformReadOnly,
+    canEdit: canEditSeries,
+    canChangeStatus: canFeaturePlans,
+    canTransfer: canTransferSeries,
+  } = useGroupContentPermissions(
+    seriesData?.group_id ?? undefined,
+    seriesStatus,
+  );
+
+  const canManageSeriesPlans = canEditSeries && !platformReadOnly;
+
   const persistPlansMutation = useMutation({
     mutationFn: (grouped: PlansByLanguage) =>
       putSeriesPlans(seriesId!, plansByLanguageToIdMap(grouped)),
@@ -108,15 +125,18 @@ const SeriesDetailsPage = () => {
   };
 
   const handleActivePlansChange = (next: SeriesPlan[]) => {
+    if (!canManageSeriesPlans) return;
     const nextRows = seriesPlansToRows(next, activeLanguage, activePlans);
     applyGrouped({ ...plansByLang, [activeLanguage]: nextRows });
   };
 
   const handleRemove = (planId: string) => {
+    if (!canManageSeriesPlans) return;
     applyGrouped(removePlanFromLanguage(plansByLang, activeLanguage, planId));
   };
 
   const handleReorder = (activeId: string, overId: string) => {
+    if (!canManageSeriesPlans) return;
     applyGrouped(
       reorderPlansInLanguage(plansByLang, activeLanguage, activeId, overId),
     );
@@ -168,13 +188,37 @@ const SeriesDetailsPage = () => {
           <IoMdArrowBack className="h-4 w-4" />
         </Pecha.Button>
         <h1 className="text-lg font-semibold">{headerTitle}</h1>
-        <Link
-          to={ROUTES.seriesEdit(seriesId)}
-          className="text-sm text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
-        >
-          Edit series
-        </Link>
+        {canEditSeries && !platformReadOnly ? (
+          <Link
+            to={ROUTES.seriesEdit(seriesId)}
+            className="text-sm text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+          >
+            Edit series
+          </Link>
+        ) : null}
+        {canTransferSeries && seriesData?.group_id && !platformReadOnly ? (
+          <DropdownButton
+            id={seriesId}
+            entityType="series"
+            currentStatus={seriesStatus}
+            triggerVariant="icon"
+            platformRole={platformRole}
+            groupRole={groupRole}
+            sourceGroupId={seriesData.group_id}
+            contentTitle={headerTitle}
+          />
+        ) : null}
       </div>
+
+      {platformReadOnly ? (
+        <p className="mx-4 mt-2 text-sm text-muted-foreground">
+          You have read-only access to this series.
+        </p>
+      ) : !canEditSeries ? (
+        <p className="mx-4 mt-2 text-sm text-muted-foreground">
+          This series cannot be edited with your current role.
+        </p>
+      ) : null}
 
       <div className="flex flex-wrap items-end justify-between gap-4 px-4 py-3">
         <div className="flex flex-wrap gap-6">
@@ -193,15 +237,18 @@ const SeriesDetailsPage = () => {
             );
           })}
         </div>
-        <div className="w-full max-w-md min-w-[280px]">
-          <PlanSearchSelector
-            value={activeSeriesPlans}
-            onChange={handleActivePlansChange}
-            searchLanguage={activeLanguage}
-            hideSelectedList
-            searchPlaceholder="Find Plans to add to series"
-          />
-        </div>
+        {canManageSeriesPlans ? (
+          <div className="w-full max-w-md min-w-[280px]">
+            <PlanSearchSelector
+              value={activeSeriesPlans}
+              onChange={handleActivePlansChange}
+              searchLanguage={activeLanguage}
+              groupId={seriesData?.group_id ?? undefined}
+              hideSelectedList
+              searchPlaceholder="Find Plans to add to series"
+            />
+          </div>
+        ) : null}
       </div>
 
       <div className="flex-1 px-4 pb-6">
@@ -210,6 +257,11 @@ const SeriesDetailsPage = () => {
             <SeriesPlansTable
               plans={activePlans}
               seriesId={seriesId}
+              sourceGroupId={seriesData?.group_id}
+              groupRole={groupRole}
+              platformRole={platformRole}
+              readOnly={platformReadOnly || !canManageSeriesPlans}
+              canFeature={canFeaturePlans}
               onReorder={handleReorder}
               onToggleFeatured={(planId) => featuredMutation.mutate(planId)}
               onRemoveFromSeries={handleRemove}
@@ -217,24 +269,26 @@ const SeriesDetailsPage = () => {
           </div>
         ) : null}
 
-        <div
-          className={`mt-4 flex min-h-[120px] items-center justify-center rounded-xl border border-dashed border-gray-300 bg-white/80 dark:border-input dark:bg-[#1d1d1f]/80 ${
-            activePlans.length > 0 ? "py-8" : "py-16"
-          }`}
-        >
-          <Link
-            to={ROUTES.planNew}
-            state={{ seriesId: seriesId!, language: activeLanguage }}
+        {canManageSeriesPlans && seriesData?.group_id ? (
+          <div
+            className={`mt-4 flex min-h-[120px] items-center justify-center rounded-xl border border-dashed border-gray-300 bg-white/80 dark:border-input dark:bg-[#1d1d1f]/80 ${
+              activePlans.length > 0 ? "py-8" : "py-16"
+            }`}
           >
-            <Pecha.Button
-              type="button"
-              className="gap-2 bg-[#A51C21] hover:bg-[#8a171c] text-white"
+            <Link
+              to={ROUTES.groupPlanNew(seriesData.group_id)}
+              state={{ seriesId: seriesId!, language: activeLanguage }}
             >
-              <IoMdAdd className="h-4 w-4" />
-              Add New Plan
-            </Pecha.Button>
-          </Link>
-        </div>
+              <Pecha.Button
+                type="button"
+                className="gap-2 bg-[#A51C21] hover:bg-[#8a171c] text-white"
+              >
+                <IoMdAdd className="h-4 w-4" />
+                Add New Plan
+              </Pecha.Button>
+            </Link>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/routes/series-details/SeriesPlanRowActions.tsx
+++ b/src/components/routes/series-details/SeriesPlanRowActions.tsx
@@ -1,19 +1,39 @@
 import { DropdownButton } from "@/components/ui/molecules/dropdown-button/DropdownButton";
 import { DASHBOARD_TABLE_ICON_BTN } from "@/components/routes/dashboard/dashboardTable";
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+import type { PlatformRole } from "@/lib/platformAccess";
+import { canEditContent } from "@/lib/contentPermissions";
 
 type SeriesPlanRowActionsProps = {
   planId: string;
+  planTitle: string;
   status: string;
   seriesId: string;
+  sourceGroupId?: string | null;
+  groupRole?: AuthorGroupMemberRole;
+  platformRole?: PlatformRole;
+  readOnly?: boolean;
   onRemoveFromSeries: () => void;
 };
 
 export function SeriesPlanRowActions({
   planId,
+  planTitle,
   status,
   seriesId,
+  sourceGroupId,
+  groupRole,
+  platformRole,
+  readOnly = false,
   onRemoveFromSeries,
 }: SeriesPlanRowActionsProps) {
+  const canRemove =
+    !readOnly && canEditContent(groupRole, status, platformRole);
+
+  const additionalMenuItems = canRemove
+    ? [{ label: "Remove from series", onClick: onRemoveFromSeries }]
+    : [];
+
   return (
     <DropdownButton
       id={planId}
@@ -22,9 +42,12 @@ export function SeriesPlanRowActions({
       triggerVariant="icon"
       triggerClassName={DASHBOARD_TABLE_ICON_BTN}
       invalidateSeriesId={seriesId}
-      additionalMenuItems={[
-        { label: "Remove from series", onClick: onRemoveFromSeries },
-      ]}
+      platformRole={platformRole}
+      groupRole={groupRole}
+      sourceGroupId={sourceGroupId}
+      contentTitle={planTitle}
+      readOnly={readOnly}
+      additionalMenuItems={additionalMenuItems}
     />
   );
 }

--- a/src/components/routes/series-details/SeriesPlansTable.tsx
+++ b/src/components/routes/series-details/SeriesPlansTable.tsx
@@ -25,6 +25,12 @@ import {
   languageChip,
   statusChip,
 } from "@/components/routes/dashboard/dashboardTableUi";
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+import {
+  canAccessPlanRoutes,
+  shouldShowCmsActionsColumn,
+  type PlatformRole,
+} from "@/lib/platformAccess";
 import type { SeriesPlanRow } from "./seriesDetailsTypes";
 import { SeriesPlanRowActions } from "./SeriesPlanRowActions";
 
@@ -38,15 +44,27 @@ function formatPlanModified(modifiedAt: string | null): string {
 function SortablePlanRow({
   plan,
   seriesId,
+  sourceGroupId,
+  groupRole,
+  platformRole,
+  readOnly,
+  canFeature,
   onToggleFeatured,
   onRemoveFromSeries,
   canReorder,
+  showActionsColumn,
 }: {
   plan: SeriesPlanRow;
   seriesId: string;
+  sourceGroupId?: string | null;
+  groupRole?: AuthorGroupMemberRole;
+  platformRole?: PlatformRole;
+  readOnly?: boolean;
+  canFeature?: boolean;
   onToggleFeatured: (planId: string) => void;
   onRemoveFromSeries: (planId: string) => void;
   canReorder: boolean;
+  showActionsColumn: boolean;
 }) {
   const navigate = useNavigate();
   const {
@@ -56,7 +74,7 @@ function SortablePlanRow({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: plan.id, disabled: !canReorder });
+  } = useSortable({ id: plan.id, disabled: !canReorder || readOnly });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -66,6 +84,7 @@ function SortablePlanRow({
 
   const daysLabel = `${plan.total_days} ${plan.total_days === 1 ? "Day" : "Days"}`;
   const featuredDisabled = plan.status !== "PUBLISHED";
+  const canOpenPlan = canAccessPlanRoutes(platformRole);
 
   return (
     <Pecha.TableRow
@@ -86,30 +105,53 @@ function SortablePlanRow({
         </button>
       </Pecha.TableCell>
       <Pecha.TableCell>
-        <button
-          type="button"
-          className="flex w-full items-center gap-3 text-left"
-          onClick={() => navigate(ROUTES.plan(plan.id))}
-        >
-          <img
-            src={plan.image_url || defaultCover}
-            onError={(e) => {
-              e.currentTarget.src = defaultCover;
-            }}
-            alt=""
-            className="h-12 w-28 shrink-0 rounded border object-cover"
-          />
-          <div className="min-w-0">
-            <div className="text-sm font-semibold">{plan.title}</div>
-            <div className="mt-1.5 flex flex-wrap gap-1.5">
-              {languageChip(plan.language)}
-              {statusChip(plan.status)}
-              <span className="rounded-full bg-[#DEAD2D4D] px-2.5 py-0.5 text-xs font-medium text-[#020C1D] dark:bg-[#DEAD2D4D] dark:text-white">
-                {daysLabel}
-              </span>
+        {canOpenPlan ? (
+          <button
+            type="button"
+            className="flex w-full items-center gap-3 text-left"
+            onClick={() => navigate(ROUTES.plan(plan.id))}
+          >
+            <img
+              src={plan.image_url || defaultCover}
+              onError={(e) => {
+                e.currentTarget.src = defaultCover;
+              }}
+              alt=""
+              className="h-12 w-28 shrink-0 rounded border object-cover"
+            />
+            <div className="min-w-0">
+              <div className="text-sm font-semibold">{plan.title}</div>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {languageChip(plan.language)}
+                {statusChip(plan.status)}
+                <span className="rounded-full bg-[#DEAD2D4D] px-2.5 py-0.5 text-xs font-medium text-[#020C1D] dark:bg-[#DEAD2D4D] dark:text-white">
+                  {daysLabel}
+                </span>
+              </div>
+            </div>
+          </button>
+        ) : (
+          <div className="flex w-full items-center gap-3 text-left">
+            <img
+              src={plan.image_url || defaultCover}
+              onError={(e) => {
+                e.currentTarget.src = defaultCover;
+              }}
+              alt=""
+              className="h-12 w-28 shrink-0 rounded border object-cover"
+            />
+            <div className="min-w-0">
+              <div className="text-sm font-semibold">{plan.title}</div>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {languageChip(plan.language)}
+                {statusChip(plan.status)}
+                <span className="rounded-full bg-[#DEAD2D4D] px-2.5 py-0.5 text-xs font-medium text-[#020C1D] dark:bg-[#DEAD2D4D] dark:text-white">
+                  {daysLabel}
+                </span>
+              </div>
             </div>
           </div>
-        </button>
+        )}
       </Pecha.TableCell>
       <Pecha.TableCell className="text-center text-sm">
         {plan.enrolled}
@@ -118,26 +160,45 @@ function SortablePlanRow({
         {formatPlanModified(plan.modifiedAt)}
       </Pecha.TableCell>
       <Pecha.TableCell className="text-center">
-        <Pecha.Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className={`${DASHBOARD_TABLE_ICON_BTN} disabled:bg-[#F3F4F6] disabled:hover:bg-[#F3F4F6] dark:disabled:bg-[#2a2a2a] dark:disabled:hover:bg-[#2a2a2a]`}
-          disabled={featuredDisabled}
-          aria-label={plan.featured ? "Featured" : "Not featured"}
-          onClick={() => onToggleFeatured(plan.id)}
-        >
-          <FeaturedStar featured={plan.featured} disabled={featuredDisabled} />
-        </Pecha.Button>
+        {canFeature && !readOnly ? (
+          <Pecha.Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className={`${DASHBOARD_TABLE_ICON_BTN} disabled:bg-[#F3F4F6] disabled:hover:bg-[#F3F4F6] dark:disabled:bg-[#2a2a2a] dark:disabled:hover:bg-[#2a2a2a]`}
+            disabled={featuredDisabled}
+            aria-label={plan.featured ? "Featured" : "Not featured"}
+            onClick={() => onToggleFeatured(plan.id)}
+          >
+            <FeaturedStar
+              featured={plan.featured}
+              disabled={featuredDisabled}
+            />
+          </Pecha.Button>
+        ) : (
+          <span
+            className={`${DASHBOARD_TABLE_ICON_BTN} inline-flex items-center justify-center`}
+            aria-hidden
+          >
+            <FeaturedStar featured={plan.featured} disabled />
+          </span>
+        )}
       </Pecha.TableCell>
-      <Pecha.TableCell className="text-center">
-        <SeriesPlanRowActions
-          planId={plan.id}
-          status={plan.status}
-          seriesId={seriesId}
-          onRemoveFromSeries={() => onRemoveFromSeries(plan.id)}
-        />
-      </Pecha.TableCell>
+      {showActionsColumn ? (
+        <Pecha.TableCell className="text-center">
+          <SeriesPlanRowActions
+            planId={plan.id}
+            planTitle={plan.title}
+            status={plan.status}
+            seriesId={seriesId}
+            sourceGroupId={sourceGroupId}
+            groupRole={groupRole}
+            platformRole={platformRole}
+            readOnly={readOnly}
+            onRemoveFromSeries={() => onRemoveFromSeries(plan.id)}
+          />
+        </Pecha.TableCell>
+      ) : null}
     </Pecha.TableRow>
   );
 }
@@ -145,6 +206,11 @@ function SortablePlanRow({
 type SeriesPlansTableProps = {
   plans: SeriesPlanRow[];
   seriesId: string;
+  sourceGroupId?: string | null;
+  groupRole?: AuthorGroupMemberRole;
+  platformRole?: PlatformRole;
+  readOnly?: boolean;
+  canFeature?: boolean;
   onReorder: (activeId: string, overId: string) => void;
   onToggleFeatured: (planId: string) => void;
   onRemoveFromSeries: (planId: string) => void;
@@ -153,6 +219,11 @@ type SeriesPlansTableProps = {
 export function SeriesPlansTable({
   plans,
   seriesId,
+  sourceGroupId,
+  groupRole,
+  platformRole,
+  readOnly = false,
+  canFeature = false,
   onReorder,
   onToggleFeatured,
   onRemoveFromSeries,
@@ -160,7 +231,9 @@ export function SeriesPlansTable({
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
   );
-  const canReorder = plans.length > 1;
+  const canReorder = !readOnly && plans.length > 1;
+  const showActionsColumn =
+    !readOnly && shouldShowCmsActionsColumn(platformRole);
   const ids = plans.map((p) => p.id);
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -192,9 +265,11 @@ export function SeriesPlansTable({
             <Pecha.TableHead className="w-[72px] text-center font-bold">
               Featured
             </Pecha.TableHead>
-            <Pecha.TableHead className="w-[100px] text-center font-bold">
-              Actions
-            </Pecha.TableHead>
+            {showActionsColumn ? (
+              <Pecha.TableHead className="w-[100px] text-center font-bold">
+                Actions
+              </Pecha.TableHead>
+            ) : null}
           </Pecha.TableRow>
         </Pecha.TableHeader>
         <SortableContext items={ids} strategy={verticalListSortingStrategy}>
@@ -204,9 +279,15 @@ export function SeriesPlansTable({
                 key={plan.id}
                 plan={plan}
                 seriesId={seriesId}
+                sourceGroupId={sourceGroupId}
+                groupRole={groupRole}
+                platformRole={platformRole}
+                readOnly={readOnly}
+                canFeature={canFeature}
                 onToggleFeatured={onToggleFeatured}
                 onRemoveFromSeries={onRemoveFromSeries}
                 canReorder={canReorder}
+                showActionsColumn={showActionsColumn}
               />
             ))}
           </Pecha.TableBody>

--- a/src/components/routes/series-details/seriesDetailsMappers.test.ts
+++ b/src/components/routes/series-details/seriesDetailsMappers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   groupPlansByLanguage,
+  mapPlanDtoToRow,
   plansByLanguageToIdMap,
   reorderPlansInLanguage,
 } from "./seriesDetailsMappers";
@@ -27,6 +28,17 @@ const plans: SeriesPlanDTO[] = [
 ];
 
 describe("seriesDetailsMappers", () => {
+  it("resolves plan cover from nested image object", () => {
+    const row = mapPlanDtoToRow({
+      id: "p1",
+      title: "Plan 1",
+      language: "EN",
+      image_url: null,
+      image: { medium: "https://example.com/cover-medium.jpg" },
+    });
+    expect(row?.image_url).toBe("https://example.com/cover-medium.jpg");
+  });
+
   it("groups and sorts plans by display_order", () => {
     const grouped = groupPlansByLanguage(plans);
     expect(grouped.EN?.map((p) => p.id)).toEqual(["p2", "p1"]);

--- a/src/components/routes/series-details/seriesDetailsMappers.ts
+++ b/src/components/routes/series-details/seriesDetailsMappers.ts
@@ -3,7 +3,11 @@ import type {
   SeriesPlanDTO,
 } from "@/components/routes/create-series/api/seriesApi";
 import type { LanguageCode } from "@/schema/SeriesSchema";
-import { normalizeStatus } from "@/components/routes/dashboard/dashboardTable";
+import {
+  normalizeStatus,
+  resolveDashboardItemImageUrl,
+  type DashboardItemImageFields,
+} from "@/components/routes/dashboard/dashboardTable";
 import type { Plan } from "@/components/routes/create-series/api/planSearchApi";
 import type { SeriesPlan } from "@/schema/SeriesSchema";
 import type { PlansByLanguage, SeriesPlanRow } from "./seriesDetailsTypes";
@@ -27,10 +31,13 @@ export function mapPlanDtoToRow(plan: SeriesPlanDTO): SeriesPlanRow | null {
   const td = plan.total_days ?? 0;
   const total_days =
     typeof td === "number" ? td : parseInt(String(td ?? "0"), 10) || 0;
+  const mappedImageUrl = resolveDashboardItemImageUrl(
+    plan as DashboardItemImageFields,
+  );
   return {
     id: String(plan.id),
     title: plan.title,
-    image_url: plan.image_url ?? "",
+    image_url: mappedImageUrl,
     language,
     status: normalizeStatus(plan.status),
     total_days,
@@ -46,7 +53,10 @@ export function mapSearchPlanToRow(plan: Plan): SeriesPlanRow | null {
   return {
     id: plan.id,
     title: plan.title,
-    image_url: plan.image_url ?? "",
+    image_url: resolveDashboardItemImageUrl({
+      image_url: plan.image_url,
+      image_key: plan.image_key,
+    }),
     language,
     status: normalizeStatus(plan.status),
     total_days: plan.total_days ?? 0,

--- a/src/components/routes/tags/Tags.tsx
+++ b/src/components/routes/tags/Tags.tsx
@@ -17,12 +17,16 @@ import {
   type Tag,
   type TagPayload,
 } from "./api/tagsApi";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { shouldShowCmsActionsColumn } from "@/lib/platformAccess";
 import TagFormDialog from "./TagFormDialog";
 import TagsTable from "./TagsTable";
 
 const PAGE_SIZE = 10;
 
 const Tags = () => {
+  const { data: userInfo } = useUserInfo();
+  const showActionsColumn = shouldShowCmsActionsColumn(userInfo?.platform_role);
   const [search, setSearch] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [debouncedSearch] = useDebounce(search, 500);
@@ -122,13 +126,15 @@ const Tags = () => {
               }}
             />
           </div>
-          <Button
-            variant="outline"
-            className="bg-gray-100 hover:bg-gray-200"
-            onClick={handleOpenCreate}
-          >
-            <IoMdAdd /> Add Tag
-          </Button>
+          {showActionsColumn ? (
+            <Button
+              variant="outline"
+              className="bg-gray-100 hover:bg-gray-200"
+              onClick={handleOpenCreate}
+            >
+              <IoMdAdd /> Add Tag
+            </Button>
+          ) : null}
         </div>
         <AuthButton />
       </div>
@@ -143,18 +149,21 @@ const Tags = () => {
         ) : tagsData?.tags.length === 0 && !isLoading ? (
           <div className="flex flex-col h-full items-center justify-center">
             <p className="text-base text-muted-foreground">No tags found</p>
-            <Button
-              variant="outline"
-              className="mt-2"
-              onClick={handleOpenCreate}
-            >
-              <IoMdAdd /> Add Tag
-            </Button>
+            {showActionsColumn ? (
+              <Button
+                variant="outline"
+                className="mt-2"
+                onClick={handleOpenCreate}
+              >
+                <IoMdAdd /> Add Tag
+              </Button>
+            ) : null}
           </div>
         ) : (
           <TagsTable
             tags={tagsData?.tags ?? []}
             isLoading={isLoading}
+            showActionsColumn={showActionsColumn}
             onEdit={handleOpenEdit}
             onDelete={setDeleteTarget}
           />

--- a/src/components/routes/tags/TagsTable.tsx
+++ b/src/components/routes/tags/TagsTable.tsx
@@ -6,11 +6,18 @@ import type { Tag } from "./api/tagsApi";
 interface TagsTableProps {
   tags: Tag[];
   isLoading?: boolean;
+  showActionsColumn?: boolean;
   onEdit: (tag: Tag) => void;
   onDelete: (tag: Tag) => void;
 }
 
-const TagsTable = ({ tags, isLoading, onEdit, onDelete }: TagsTableProps) => {
+const TagsTable = ({
+  tags,
+  isLoading,
+  showActionsColumn = true,
+  onEdit,
+  onDelete,
+}: TagsTableProps) => {
   if (isLoading) {
     return (
       <p className="text-sm text-muted-foreground py-8 text-center">
@@ -28,9 +35,11 @@ const TagsTable = ({ tags, isLoading, onEdit, onDelete }: TagsTableProps) => {
             <Pecha.TableHead>Name</Pecha.TableHead>
             <Pecha.TableHead>Description</Pecha.TableHead>
             <Pecha.TableHead className="w-24">Plans</Pecha.TableHead>
-            <Pecha.TableHead className="w-28 text-right">
-              Actions
-            </Pecha.TableHead>
+            {showActionsColumn ? (
+              <Pecha.TableHead className="w-28 text-right">
+                Actions
+              </Pecha.TableHead>
+            ) : null}
           </Pecha.TableRow>
         </Pecha.TableHeader>
         <Pecha.TableBody>
@@ -50,26 +59,28 @@ const TagsTable = ({ tags, isLoading, onEdit, onDelete }: TagsTableProps) => {
                 {tag.description || "—"}
               </Pecha.TableCell>
               <Pecha.TableCell>{tag.plan_ids.length}</Pecha.TableCell>
-              <Pecha.TableCell>
-                <div className="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={() => onEdit(tag)}
-                    className="p-2 rounded-md border hover:bg-muted/50 transition-colors"
-                    aria-label={`Edit ${tag.name}`}
-                  >
-                    <IoMdCreate className="w-4 h-4" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onDelete(tag)}
-                    className="p-2 rounded-md border text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
-                    aria-label={`Delete ${tag.name}`}
-                  >
-                    <IoMdTrash className="w-4 h-4" />
-                  </button>
-                </div>
-              </Pecha.TableCell>
+              {showActionsColumn ? (
+                <Pecha.TableCell>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(tag)}
+                      className="p-2 rounded-md border hover:bg-muted/50 transition-colors"
+                      aria-label={`Edit ${tag.name}`}
+                    >
+                      <IoMdCreate className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(tag)}
+                      className="p-2 rounded-md border text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+                      aria-label={`Delete ${tag.name}`}
+                    >
+                      <IoMdTrash className="w-4 h-4" />
+                    </button>
+                  </div>
+                </Pecha.TableCell>
+              ) : null}
             </Pecha.TableRow>
           ))}
         </Pecha.TableBody>

--- a/src/components/routes/task/PlanDetailsPage.test.tsx
+++ b/src/components/routes/task/PlanDetailsPage.test.tsx
@@ -139,7 +139,16 @@ describe("PlanDetailsPanel Component", () => {
     vi.clearAllMocks();
     const { default: axiosInstance } = await import("@/config/axios-config");
     const mockAxios = axiosInstance as any;
-    mockAxios.get.mockResolvedValue({ data: mockPlanData });
+    mockAxios.get.mockImplementation((url: string) => {
+      if (String(url).includes("/groups/")) {
+        return Promise.resolve({
+          data: { id: "g1", members: [], metadata: [], slug: "g" },
+        });
+      }
+      return Promise.resolve({
+        data: { ...mockPlanData, status: "DRAFT", group_id: "g1" },
+      });
+    });
     mockAxios.post.mockResolvedValue({
       data: { id: "new-day-id", day_number: 5, tasks: [] },
     });

--- a/src/components/routes/task/PlanDetailsPage.tsx
+++ b/src/components/routes/task/PlanDetailsPage.tsx
@@ -7,6 +7,10 @@ import SideBar from "./components/sidebar-component/SideBar";
 import TaskView from "./components/view/TaskView";
 import MobileView from "./components/MobileView";
 import { fetchPlanDetails } from "./api/planApi";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { fetchGroup } from "@/components/routes/groups/api/groupsApi";
+import { getCurrentUserGroupRole } from "@/components/routes/groups/lib/groupPermissions";
+import { canEditContent } from "@/lib/contentPermissions";
 import { HiOutlineDeviceMobile } from "react-icons/hi";
 
 const PlanDetailsPage = () => {
@@ -53,13 +57,32 @@ const PlanDetailsPage = () => {
     setEditingTask(null);
   }, [selectedDay]);
 
+  const { data: userInfo } = useUserInfo();
+
   const { data: planDetails } = useQuery({
     queryKey: ["planDetails", planId],
     queryFn: () => fetchPlanDetails(planId!),
     enabled: !!planId,
   });
 
-  const isEditable = true;
+  const groupId = planDetails?.group_id as string | undefined;
+
+  const { data: planGroup } = useQuery({
+    queryKey: ["cms-group", groupId],
+    queryFn: () => fetchGroup(groupId!),
+    enabled: Boolean(groupId),
+    refetchOnWindowFocus: false,
+  });
+
+  const groupRole = planGroup
+    ? getCurrentUserGroupRole(planGroup.members ?? [], userInfo)
+    : undefined;
+
+  const isEditable = canEditContent(
+    groupRole,
+    planDetails?.status ?? "DRAFT",
+    userInfo?.platform_role,
+  );
   const isPlanPublished = planDetails?.status === "PUBLISHED";
   const currentDayData = planDetails?.days?.find(
     (day: { day_number: number }) => day.day_number === selectedDay,

--- a/src/components/ui/molecules/dropdown-button/DropdownButton.tsx
+++ b/src/components/ui/molecules/dropdown-button/DropdownButton.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Pecha } from "@/components/ui/shadimport";
 import { FaPen } from "react-icons/fa";
 import { BsThreeDotsVertical } from "react-icons/bs";
@@ -5,14 +6,24 @@ import { IoMdTrash, IoMdArchive } from "react-icons/io";
 import { MdOutlineFileUpload } from "react-icons/md";
 import { IoEyeOffSharp } from "react-icons/io5";
 import { RiDraftLine } from "react-icons/ri";
+import { MdSwapHoriz } from "react-icons/md";
 import { toast } from "sonner";
 import { Link } from "react-router-dom";
 import { ROUTES } from "@/routes/paths";
 import PlanDeleteDialog from "@/components/ui/molecules/modals/plan-delete/PlanDeleteDialog";
+import ContentTransferDialog from "@/components/routes/content-transfer/components/ContentTransferDialog";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
 import { STATUS_TRANSITIONS, ALLOWED_TRANSITIONS } from "@/lib/constant";
 import { normalizeStatus } from "@/components/routes/dashboard/dashboardTable";
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+import type { PlatformRole } from "@/lib/platformAccess";
+import {
+  canChangeContentStatus,
+  canDeleteContent,
+  canEditContent,
+  canInitiateContentTransfer,
+} from "@/lib/contentPermissions";
 
 export type DropdownAdditionalMenuItem = {
   label: string;
@@ -36,6 +47,11 @@ export function DropdownButton({
   entityType = "plan",
   additionalMenuItems,
   invalidateSeriesId,
+  readOnly = false,
+  groupRole,
+  platformRole,
+  sourceGroupId,
+  contentTitle,
 }: {
   id: string;
   currentStatus: string;
@@ -45,8 +61,15 @@ export function DropdownButton({
   additionalMenuItems?: DropdownAdditionalMenuItem[];
   /** When plan actions run on series details, refresh that series query too. */
   invalidateSeriesId?: string;
+  readOnly?: boolean;
+  groupRole?: AuthorGroupMemberRole;
+  platformRole?: PlatformRole;
+  /** Current owning group; required to show transfer action. */
+  sourceGroupId?: string | null;
+  contentTitle?: string;
 }) {
   const queryClient = useQueryClient();
+  const [transferOpen, setTransferOpen] = useState(false);
   const isSeries = entityType === "series";
   const apiBase = isSeries ? "/api/v1/cms/series" : "/api/v1/cms/plans";
   const editHref = isSeries ? ROUTES.seriesEdit(id) : ROUTES.planEdit(id);
@@ -117,8 +140,55 @@ export function DropdownButton({
     allowedStatuses.includes(statusOption.value),
   );
 
-  const canEditDelete = status === "DRAFT" || status === "ARCHIVED";
   const extraItems = additionalMenuItems ?? [];
+  const allowEdit =
+    !readOnly && canEditContent(groupRole, status, platformRole);
+  const allowDelete =
+    !readOnly && canDeleteContent(groupRole, status, platformRole);
+  const allowStatus =
+    !readOnly && canChangeContentStatus(groupRole, platformRole);
+  const allowTransfer =
+    !readOnly &&
+    Boolean(sourceGroupId) &&
+    canInitiateContentTransfer(groupRole, platformRole);
+
+  const invalidateAfterTransfer = () => {
+    queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
+    queryClient.invalidateQueries({ queryKey: ["transfer-requests"] });
+    if (isSeries) {
+      queryClient.invalidateQueries({ queryKey: ["series", id] });
+    } else {
+      queryClient.invalidateQueries({ queryKey: ["planDetails", id] });
+      if (invalidateSeriesId) {
+        queryClient.invalidateQueries({
+          queryKey: ["series", invalidateSeriesId],
+        });
+      }
+    }
+  };
+
+  if (readOnly) {
+    return (
+      <span className="text-xs text-muted-foreground" aria-hidden>
+        —
+      </span>
+    );
+  }
+
+  const hasMenuItems =
+    allowEdit ||
+    allowDelete ||
+    allowStatus ||
+    allowTransfer ||
+    extraItems.length > 0;
+
+  if (!hasMenuItems) {
+    return (
+      <span className="text-xs text-muted-foreground" aria-hidden>
+        —
+      </span>
+    );
+  }
 
   return (
     <Pecha.ButtonGroup className="mx-auto">
@@ -140,31 +210,53 @@ export function DropdownButton({
           )}
         </Pecha.DropdownMenuTrigger>
         <Pecha.DropdownMenuContent align="end" className="[--radius:1rem]">
-          <Pecha.DropdownMenuGroup>
-            <Link to={editHref}>
-              <Pecha.DropdownMenuItem>
-                <FaPen className="h-4 w-4" />
-                {editLabel}
-              </Pecha.DropdownMenuItem>
-            </Link>
-          </Pecha.DropdownMenuGroup>
-          <Pecha.DropdownMenuSeparator />
-          <Pecha.DropdownMenuItem disabled>Status</Pecha.DropdownMenuItem>
-          <Pecha.DropdownMenuGroup>
-            {availableTransitions.map((status) => {
-              const IconComponent =
-                STATUS_ICONS[status.value as keyof typeof STATUS_ICONS];
-              return (
-                <Pecha.DropdownMenuItem
-                  key={status.value}
-                  onClick={() => handleStatusChange(status.value)}
-                >
-                  <IconComponent className="h-4 w-4" />
-                  {status.label}
+          {allowEdit ? (
+            <Pecha.DropdownMenuGroup>
+              <Link to={editHref}>
+                <Pecha.DropdownMenuItem>
+                  <FaPen className="h-4 w-4" />
+                  {editLabel}
                 </Pecha.DropdownMenuItem>
-              );
-            })}
-          </Pecha.DropdownMenuGroup>
+              </Link>
+            </Pecha.DropdownMenuGroup>
+          ) : null}
+          {allowStatus ? (
+            <>
+              <Pecha.DropdownMenuSeparator />
+              <Pecha.DropdownMenuItem disabled>Status</Pecha.DropdownMenuItem>
+              <Pecha.DropdownMenuGroup>
+                {availableTransitions.map((status) => {
+                  const IconComponent =
+                    STATUS_ICONS[status.value as keyof typeof STATUS_ICONS];
+                  return (
+                    <Pecha.DropdownMenuItem
+                      key={status.value}
+                      onClick={() => handleStatusChange(status.value)}
+                    >
+                      <IconComponent className="h-4 w-4" />
+                      {status.label}
+                    </Pecha.DropdownMenuItem>
+                  );
+                })}
+              </Pecha.DropdownMenuGroup>
+            </>
+          ) : null}
+          {allowTransfer && sourceGroupId ? (
+            <>
+              <Pecha.DropdownMenuSeparator />
+              <Pecha.DropdownMenuGroup>
+                <Pecha.DropdownMenuItem
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    setTransferOpen(true);
+                  }}
+                >
+                  <MdSwapHoriz className="h-4 w-4" />
+                  Transfer to group…
+                </Pecha.DropdownMenuItem>
+              </Pecha.DropdownMenuGroup>
+            </>
+          ) : null}
           {extraItems.length > 0 && (
             <>
               <Pecha.DropdownMenuSeparator />
@@ -180,7 +272,7 @@ export function DropdownButton({
               </Pecha.DropdownMenuGroup>
             </>
           )}
-          {canEditDelete && (
+          {allowDelete && (
             <>
               <Pecha.DropdownMenuSeparator />
               <Pecha.DropdownMenuGroup>
@@ -207,6 +299,17 @@ export function DropdownButton({
           )}
         </Pecha.DropdownMenuContent>
       </Pecha.DropdownMenu>
+      {allowTransfer && sourceGroupId ? (
+        <ContentTransferDialog
+          open={transferOpen}
+          onOpenChange={setTransferOpen}
+          contentType={entityType}
+          contentId={id}
+          sourceGroupId={sourceGroupId}
+          contentTitle={contentTitle}
+          onSuccess={invalidateAfterTransfer}
+        />
+      ) : null}
     </Pecha.ButtonGroup>
   );
 }

--- a/src/components/ui/molecules/nav-bar/Navbar.tsx
+++ b/src/components/ui/molecules/nav-bar/Navbar.tsx
@@ -15,6 +15,9 @@ import {
 } from "../../atoms/tooltip";
 import AuthAvatar from "@/components/ui/molecules/auth-avatar/AuthAvatar";
 import NotificationBell from "@/components/ui/molecules/notification-bell/NotificationBell";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { canAccessAdminAuthors } from "@/lib/platformAccess";
+import { MdAdminPanelSettings } from "react-icons/md";
 
 const navItems = [
   {
@@ -70,6 +73,22 @@ const tooltipItems = [
 
 const Navbar = () => {
   const location = useLocation();
+  const { data: userInfo } = useUserInfo();
+  const showAdminAuthors = canAccessAdminAuthors(userInfo?.platform_role);
+
+  const allNavItems = [
+    ...navItems,
+    ...(showAdminAuthors
+      ? [
+          {
+            icon: <MdAdminPanelSettings className="w-4 h-4" />,
+            label: "Authors",
+            path: ROUTES.adminAuthors,
+            tooltip: "Author administration",
+          },
+        ]
+      : []),
+  ];
 
   return (
     <TooltipProvider>
@@ -86,7 +105,7 @@ const Navbar = () => {
             />
           </Link>
           <div className="flex flex-col space-y-4 items-center w-full">
-            {navItems.map((item, index) => (
+            {allNavItems.map((item, index) => (
               <Tooltip key={index}>
                 <TooltipTrigger asChild>
                   <Link
@@ -96,7 +115,9 @@ const Navbar = () => {
                       (item.path === ROUTES.dashboard &&
                         location.pathname === "/") ||
                       (item.path === ROUTES.groups &&
-                        location.pathname.startsWith("/groups"))
+                        location.pathname.startsWith("/groups")) ||
+                      (item.path === ROUTES.adminAuthors &&
+                        location.pathname.startsWith(ROUTES.adminAuthors))
                         ? "text-zinc-900 dark:text-zinc-100"
                         : "text-zinc-400 dark:text-zinc-600"
                     }`}

--- a/src/components/ui/molecules/notification-bell/NotificationBell.tsx
+++ b/src/components/ui/molecules/notification-bell/NotificationBell.tsx
@@ -17,7 +17,13 @@ import {
   rejectGroupInvite,
 } from "@/components/routes/groups/api/groupsApi";
 import {
+  acceptTransferRequest,
+  rejectTransferRequest,
+} from "@/components/routes/content-transfer/api/transferApi";
+import {
   fetchNotifications,
+  getTransferNotificationTargetGroupId,
+  isContentTransferNotification,
   isGroupInviteNotification,
   markNotificationRead,
   type NotificationDTO,
@@ -92,7 +98,45 @@ const NotificationBell = () => {
     inviteActionMutation.mutate({ inviteId, action });
   };
 
-  const invitePending = inviteActionMutation.isPending;
+  const transferActionMutation = useMutation({
+    mutationFn: async ({
+      requestId,
+      action,
+    }: {
+      requestId: string;
+      action: "accept" | "reject";
+    }) => {
+      if (action === "accept") {
+        return acceptTransferRequest(requestId);
+      }
+      await rejectTransferRequest(requestId);
+      return null;
+    },
+    onSuccess: (_data, { action }) => {
+      toast.success(
+        action === "accept" ? "Transfer accepted" : "Transfer rejected",
+      );
+      invalidateNotifications();
+      queryClient.invalidateQueries({ queryKey: ["transfer-requests"] });
+      queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const handleTransferAction = (
+    notification: NotificationDTO,
+    action: "accept" | "reject",
+  ) => {
+    const requestId = notification.reference_id;
+    if (!requestId) {
+      toast.error("Invalid transfer notification");
+      return;
+    }
+    transferActionMutation.mutate({ requestId, action });
+  };
+
+  const invitePending =
+    inviteActionMutation.isPending || transferActionMutation.isPending;
 
   const handleMenuOpenChange = (next: boolean) => {
     setOpen(next);
@@ -191,6 +235,55 @@ const NotificationBell = () => {
                           ? "Declining…"
                           : "Reject"}
                       </Button>
+                    </div>
+                  )}
+                  {isContentTransferNotification(notification) && (
+                    <div className="flex flex-col gap-2">
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90 h-7 text-xs"
+                          disabled={invitePending}
+                          onClick={() =>
+                            handleTransferAction(notification, "accept")
+                          }
+                        >
+                          Accept
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="h-7 text-xs"
+                          disabled={invitePending}
+                          onClick={() =>
+                            handleTransferAction(notification, "reject")
+                          }
+                        >
+                          Reject
+                        </Button>
+                      </div>
+                      {getTransferNotificationTargetGroupId(notification) ? (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="link"
+                          className="h-auto p-0 text-xs text-[#A51C21]"
+                          onClick={() => {
+                            setOpen(false);
+                            navigate(
+                              `${ROUTES.group(
+                                getTransferNotificationTargetGroupId(
+                                  notification,
+                                )!,
+                              )}?tab=transfers`,
+                            );
+                          }}
+                        >
+                          View on group page
+                        </Button>
+                      ) : null}
                     </div>
                   )}
                 </div>

--- a/src/components/ui/molecules/profile-edit-form/ProfileEditForm.tsx
+++ b/src/components/ui/molecules/profile-edit-form/ProfileEditForm.tsx
@@ -112,7 +112,7 @@ const ProfileEditForm = ({ userInfo, onSuccess }: ProfileEditFormProps) => {
       });
       setIsImageDialogOpen(false);
       toast.success("Image uploaded successfully!");
-    } catch (error) {
+    } catch {
       toast.error("Failed to upload image");
     } finally {
       setIsImageUploading(false);

--- a/src/hooks/useDashboardGroupFilterOptions.ts
+++ b/src/hooks/useDashboardGroupFilterOptions.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchAccessibleGroupsForDashboard,
+  pickGroupTitle,
+  type AuthorGroupListItem,
+} from "@/components/routes/groups/api/groupsApi";
+import type { PlatformRole } from "@/lib/platformAccess";
+import { isReviewer, isSuperAdmin } from "@/lib/platformAccess";
+
+export type DashboardGroupFilterOption = {
+  id: string;
+  title: string;
+};
+
+function toFilterOptions(
+  groups: AuthorGroupListItem[],
+): DashboardGroupFilterOption[] {
+  return groups.map((group) => ({
+    id: group.id,
+    title: pickGroupTitle(group.metadata),
+  }));
+}
+
+export function useDashboardGroupFilterOptions(
+  platformRole?: PlatformRole | string,
+) {
+  const staffWideList = isSuperAdmin(platformRole) || isReviewer(platformRole);
+
+  const query = useQuery({
+    queryKey: ["dashboard-group-filter", platformRole],
+    queryFn: () => fetchAccessibleGroupsForDashboard(platformRole),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const options = toFilterOptions(query.data ?? []);
+
+  return {
+    options,
+    isLoading: query.isLoading,
+    isStaffWideList: staffWideList,
+    showFilter: options.length > 0 || staffWideList,
+  };
+}

--- a/src/hooks/useDashboardGroupFilterOptions.ts
+++ b/src/hooks/useDashboardGroupFilterOptions.ts
@@ -1,44 +1,90 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   fetchAccessibleGroupsForDashboard,
   pickGroupTitle,
   type AuthorGroupListItem,
 } from "@/components/routes/groups/api/groupsApi";
-import type { PlatformRole } from "@/lib/platformAccess";
-import { isReviewer, isSuperAdmin } from "@/lib/platformAccess";
+import type { UserInfo } from "@/hooks/useUserInfo";
+import { useGroupRolesMap } from "@/hooks/useGroupRolesMap";
+import {
+  canUseDashboardGroupFilter,
+  usesStaffWideDashboardGroupList,
+} from "@/lib/platformAccess";
 
 export type DashboardGroupFilterOption = {
   id: string;
   title: string;
+  /** Dropdown label (includes membership role for creators when known). */
+  label: string;
 };
 
 function toFilterOptions(
   groups: AuthorGroupListItem[],
+  rolesByGroupId: Map<string, string | undefined>,
+  showMemberRole: boolean,
 ): DashboardGroupFilterOption[] {
-  return groups.map((group) => ({
-    id: group.id,
-    title: pickGroupTitle(group.metadata),
-  }));
+  return groups.map((group) => {
+    const title = pickGroupTitle(group.metadata);
+    const role = rolesByGroupId.get(group.id);
+    const label = showMemberRole && role ? `${title} (${role})` : title;
+    return { id: group.id, title, label };
+  });
 }
 
-export function useDashboardGroupFilterOptions(
-  platformRole?: PlatformRole | string,
-) {
-  const staffWideList = isSuperAdmin(platformRole) || isReviewer(platformRole);
+export function useDashboardGroupFilterOptions(userInfo?: UserInfo | null) {
+  const platformRole = userInfo?.platform_role;
+  const isStaffWideList = usesStaffWideDashboardGroupList(platformRole);
+  const canLoad = canUseDashboardGroupFilter(userInfo);
 
   const query = useQuery({
-    queryKey: ["dashboard-group-filter", platformRole],
-    queryFn: () => fetchAccessibleGroupsForDashboard(platformRole),
+    queryKey: ["dashboard-group-filter", platformRole, userInfo?.has_group],
+    queryFn: () => fetchAccessibleGroupsForDashboard(userInfo),
+    enabled: canLoad,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
-  const options = toFilterOptions(query.data ?? []);
+  const groupIds = useMemo(
+    () => (query.data ?? []).map((g) => g.id),
+    [query.data],
+  );
+
+  const userActor = userInfo
+    ? {
+        id: userInfo.id,
+        email: userInfo.email,
+        platform_role: userInfo.platform_role,
+      }
+    : undefined;
+
+  const memberRolesByGroupId = useGroupRolesMap(
+    isStaffWideList ? [] : groupIds,
+    userActor,
+  );
+
+  const roleLabels = useMemo(() => {
+    const map = new Map<string, string | undefined>();
+    memberRolesByGroupId.forEach((role, id) => {
+      if (role) map.set(id, role);
+    });
+    return map;
+  }, [memberRolesByGroupId]);
+
+  const options = useMemo(
+    () => toFilterOptions(query.data ?? [], roleLabels, !isStaffWideList),
+    [query.data, roleLabels, isStaffWideList],
+  );
 
   return {
     options,
     isLoading: query.isLoading,
-    isStaffWideList: staffWideList,
-    showFilter: options.length > 0 || staffWideList,
+    isStaffWideList,
+    showFilter: canLoad && (options.length > 0 || isStaffWideList),
+    /** Creators: only group_ids returned from the membership list API. */
+    allowedGroupIds: useMemo(
+      () => new Set(options.map((g) => g.id)),
+      [options],
+    ),
   };
 }

--- a/src/hooks/useGroupContentPermissions.ts
+++ b/src/hooks/useGroupContentPermissions.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchGroup } from "@/components/routes/groups/api/groupsApi";
+import { getEffectiveGroupRole } from "@/components/routes/groups/lib/groupPermissions";
+import {
+  canChangeContentStatus,
+  canDeleteContent,
+  canEditContent,
+  canInitiateContentTransfer,
+  type ContentStatus,
+} from "@/lib/contentPermissions";
+import { isReviewer, type PlatformRole } from "@/lib/platformAccess";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+
+export function useGroupContentPermissions(
+  groupId: string | undefined,
+  contentStatus: ContentStatus = "DRAFT",
+) {
+  const { data: userInfo } = useUserInfo();
+
+  const { data: group, isLoading: isGroupLoading } = useQuery({
+    queryKey: ["cms-group", groupId],
+    queryFn: () => fetchGroup(groupId!),
+    enabled: Boolean(groupId),
+    refetchOnWindowFocus: false,
+  });
+
+  const groupRole: AuthorGroupMemberRole | undefined = group
+    ? getEffectiveGroupRole(group.members ?? [], userInfo)
+    : undefined;
+
+  const platformRole = userInfo?.platform_role as PlatformRole | undefined;
+  const platformReadOnly = isReviewer(platformRole);
+
+  return {
+    userInfo,
+    group,
+    groupRole,
+    platformRole,
+    platformReadOnly,
+    isGroupLoading,
+    canEdit: canEditContent(groupRole, contentStatus, platformRole),
+    canChangeStatus: canChangeContentStatus(groupRole, platformRole),
+    canDelete: canDeleteContent(groupRole, contentStatus, platformRole),
+    canTransfer: canInitiateContentTransfer(groupRole, platformRole),
+  };
+}

--- a/src/hooks/useGroupRolesMap.ts
+++ b/src/hooks/useGroupRolesMap.ts
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import { useQueries } from "@tanstack/react-query";
+import {
+  fetchGroup,
+  type AuthorGroupMemberRole,
+} from "@/components/routes/groups/api/groupsApi";
+import {
+  getCurrentUserGroupRole,
+  type GroupActor,
+} from "@/components/routes/groups/lib/groupPermissions";
+
+/** Resolves the current user's role in each group (for content permission checks). */
+export function useGroupRolesMap(
+  groupIds: (string | null | undefined)[],
+  user: GroupActor | undefined,
+): Map<string, AuthorGroupMemberRole | undefined> {
+  const uniqueIds = useMemo(
+    () => [...new Set(groupIds.filter((id): id is string => Boolean(id)))],
+    [groupIds],
+  );
+
+  const queries = useQueries({
+    queries: uniqueIds.map((groupId) => ({
+      queryKey: ["cms-group", groupId],
+      queryFn: () => fetchGroup(groupId),
+      staleTime: 5 * 60 * 1000,
+      enabled: Boolean(groupId),
+    })),
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, AuthorGroupMemberRole | undefined>();
+    uniqueIds.forEach((groupId, index) => {
+      const members = queries[index]?.data?.members ?? [];
+      map.set(groupId, getCurrentUserGroupRole(members, user));
+    });
+    return map;
+  }, [uniqueIds, queries, user]);
+}

--- a/src/hooks/useUserInfo.ts
+++ b/src/hooks/useUserInfo.ts
@@ -1,8 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import axiosInstance from "@/config/axios-config";
 import { useAuth } from "@/config/auth-context";
+import { normalizePlatformRole, type PlatformRole } from "@/lib/platformAccess";
 
 export const USER_INFO_QUERY_KEY = ["userInfo"] as const;
+export type { PlatformRole };
 
 export type SocialMediaProfile = {
   account: string;
@@ -14,7 +16,11 @@ export type UserInfo = {
   firstname?: string;
   lastname?: string;
   email?: string;
-  is_admin?: boolean;
+  platform_role?: PlatformRole;
+  is_verified?: boolean;
+  is_active?: boolean;
+  has_group?: boolean;
+  can_create_content?: boolean;
   image_url?: string | null;
   bio?: string | null;
   image?: { thumbnail?: string; medium?: string; original?: string } | null;
@@ -23,7 +29,21 @@ export type UserInfo = {
 
 export const fetchUserInfo = async (): Promise<UserInfo> => {
   const { data } = await axiosInstance.get<UserInfo>(`/api/v1/authors/info`);
-  return data;
+  const platform_role = normalizePlatformRole(data.platform_role);
+  const has_group =
+    data.has_group ??
+    (platform_role === "SUPER_ADMIN" || platform_role === "REVIEWER");
+
+  return {
+    ...data,
+    platform_role,
+    is_verified: data.is_verified ?? true,
+    is_active: data.is_active ?? true,
+    has_group,
+    can_create_content:
+      data.can_create_content ??
+      (platform_role === "SUPER_ADMIN" || has_group === true),
+  };
 };
 
 /** Shared author profile query — all consumers dedupe to one request via `USER_INFO_QUERY_KEY`. */

--- a/src/lib/apiErrors.ts
+++ b/src/lib/apiErrors.ts
@@ -1,11 +1,12 @@
-export function getApiErrorMessage(
-  error: unknown,
-  fallback = "Something went wrong",
-): string {
+import {
+  AUTHOR_NOT_ACTIVE_DETAIL,
+  isAuthorNotActiveDetail,
+} from "@/lib/platformAccess";
+
+export function getApiErrorDetail(error: unknown): string | undefined {
   const err = error as { response?: { data?: { detail?: unknown } } };
   const detail = err?.response?.data?.detail;
   if (typeof detail === "string") return detail;
-  if (Array.isArray(detail) && detail[0]?.msg) return detail[0].msg;
   if (
     detail &&
     typeof detail === "object" &&
@@ -14,5 +15,37 @@ export function getApiErrorMessage(
   ) {
     return (detail as { message: string }).message;
   }
+  return undefined;
+}
+
+const FRIENDLY_MESSAGES: Record<string, string> = {
+  [AUTHOR_NOT_ACTIVE_DETAIL]: AUTHOR_NOT_ACTIVE_DETAIL,
+  CONTENT_PUBLISHED_READ_ONLY:
+    "Published content is read-only for your role in this group.",
+  STATUS_CHANGE_FORBIDDEN:
+    "You cannot change the status of this content with your current role.",
+  NO_GROUP_MEMBERSHIP: "You are not a member of this content's group.",
+  "Target group must differ from the current group":
+    "Choose a different group than the content's current group.",
+  "Target group not found": "That group could not be found.",
+  "A pending transfer request already exists for this content":
+    "A transfer request is already pending for this content.",
+  "Plan is attached to a series; transfer the series or detach the plan first":
+    "Transfer the series instead, or detach the plan from the series first.",
+};
+
+export function getApiErrorMessage(
+  error: unknown,
+  fallback = "Something went wrong",
+): string {
+  const detail = getApiErrorDetail(error);
+  if (detail) {
+    if (FRIENDLY_MESSAGES[detail]) return FRIENDLY_MESSAGES[detail];
+    if (isAuthorNotActiveDetail(detail)) return AUTHOR_NOT_ACTIVE_DETAIL;
+    return detail;
+  }
+  const err = error as { response?: { data?: { detail?: unknown } } };
+  const rawDetail = err?.response?.data?.detail;
+  if (Array.isArray(rawDetail) && rawDetail[0]?.msg) return rawDetail[0].msg;
   return fallback;
 }

--- a/src/lib/contentPermissions.test.ts
+++ b/src/lib/contentPermissions.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { canDeleteContent, canEditContent } from "./contentPermissions";
+
+describe("contentPermissions", () => {
+  it("allows group AUTHOR to edit but not delete DRAFT content", () => {
+    expect(canEditContent("AUTHOR", "DRAFT")).toBe(true);
+    expect(canDeleteContent("AUTHOR", "DRAFT")).toBe(false);
+    expect(canDeleteContent("AUTHOR", "PUBLISHED")).toBe(false);
+  });
+
+  it("allows OWNER to delete DRAFT and ARCHIVED", () => {
+    expect(canDeleteContent("OWNER", "DRAFT")).toBe(true);
+    expect(canDeleteContent("OWNER", "ARCHIVED")).toBe(true);
+  });
+});

--- a/src/lib/contentPermissions.ts
+++ b/src/lib/contentPermissions.ts
@@ -1,0 +1,60 @@
+import type { PlatformRole } from "@/lib/platformAccess";
+import { isSuperAdmin } from "@/lib/platformAccess";
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+
+export type ContentStatus =
+  | "DRAFT"
+  | "PUBLISHED"
+  | "UNPUBLISHED"
+  | "ARCHIVED"
+  | string;
+
+export function canEditContent(
+  groupRole: AuthorGroupMemberRole | undefined,
+  status: ContentStatus,
+  platformRole?: PlatformRole | string,
+): boolean {
+  if (isSuperAdmin(platformRole)) return true;
+  if (!groupRole || groupRole === "VIEWER") return false;
+  if (groupRole === "AUTHOR") {
+    return status === "DRAFT";
+  }
+  if (groupRole === "OWNER" || groupRole === "ADMIN") return true;
+  return false;
+}
+
+export function canChangeContentStatus(
+  groupRole: AuthorGroupMemberRole | undefined,
+  platformRole?: PlatformRole | string,
+): boolean {
+  if (isSuperAdmin(platformRole)) return true;
+  return groupRole === "OWNER" || groupRole === "ADMIN";
+}
+
+/** Only OWNER, ADMIN, or SUPER_ADMIN may delete group content (never group AUTHOR). */
+export function canDeleteContent(
+  groupRole: AuthorGroupMemberRole | undefined,
+  status: ContentStatus,
+  platformRole?: PlatformRole | string,
+): boolean {
+  if (isSuperAdmin(platformRole)) {
+    return (
+      status === "DRAFT" || status === "ARCHIVED" || status === "UNPUBLISHED"
+    );
+  }
+  if (!groupRole || groupRole === "VIEWER" || groupRole === "AUTHOR") {
+    return false;
+  }
+  if (groupRole === "OWNER" || groupRole === "ADMIN") {
+    return status === "DRAFT" || status === "ARCHIVED";
+  }
+  return false;
+}
+
+export function canInitiateContentTransfer(
+  groupRole: AuthorGroupMemberRole | undefined,
+  platformRole?: PlatformRole | string,
+): boolean {
+  if (isSuperAdmin(platformRole)) return true;
+  return groupRole === "OWNER" || groupRole === "ADMIN";
+}

--- a/src/lib/dashboardRowPermissions.test.ts
+++ b/src/lib/dashboardRowPermissions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { resolveDashboardRowGroupRole } from "./dashboardRowPermissions";
+import type { DashboardTableRow } from "@/components/routes/dashboard/dashboardTable";
+
+const baseRow: DashboardTableRow = {
+  kind: "plan",
+  id: "p1",
+  title: "Test",
+  image_url: "",
+  languages: ["EN"],
+  status: "DRAFT",
+  total_days: 1,
+  enrolled: 0,
+  modifiedAt: null,
+  featured: false,
+};
+
+describe("resolveDashboardRowGroupRole", () => {
+  it("uses map role when group_id is present", () => {
+    const map = new Map([["g1", "OWNER" as const]]);
+    expect(
+      resolveDashboardRowGroupRole({ ...baseRow, group_id: "g1" }, map, {
+        id: "u1",
+        platform_role: "CREATOR",
+        can_create_content: true,
+      }),
+    ).toBe("OWNER");
+  });
+
+  it("falls back to AUTHOR for CREATOR on DRAFT when role unknown", () => {
+    expect(
+      resolveDashboardRowGroupRole({ ...baseRow, group_id: null }, new Map(), {
+        id: "u1",
+        platform_role: "CREATOR",
+        can_create_content: true,
+        is_active: true,
+        has_group: true,
+      }),
+    ).toBe("AUTHOR");
+  });
+});

--- a/src/lib/dashboardRowPermissions.ts
+++ b/src/lib/dashboardRowPermissions.ts
@@ -1,0 +1,39 @@
+import type { AuthorGroupMemberRole } from "@/components/routes/groups/api/groupsApi";
+import type { DashboardTableRow } from "@/components/routes/dashboard/dashboardTable";
+import type { UserInfo } from "@/hooks/useUserInfo";
+import { isSuperAdmin } from "@/lib/platformAccess";
+
+/**
+ * Resolves group role for a dashboard row.
+ * When the list API omits group_id, enrichment may still fail — CREATORs with
+ * can_create_content get AUTHOR-level edit on DRAFT rows as a safe default (not delete).
+ */
+export function resolveDashboardRowGroupRole(
+  row: DashboardTableRow,
+  groupRolesByGroupId:
+    | Map<string, AuthorGroupMemberRole | undefined>
+    | undefined,
+  userInfo?: UserInfo | null,
+): AuthorGroupMemberRole | undefined {
+  if (isSuperAdmin(userInfo?.platform_role)) {
+    return groupRolesByGroupId?.get(row.group_id ?? "") ?? "OWNER";
+  }
+
+  if (row.group_id) {
+    const role = groupRolesByGroupId?.get(row.group_id);
+    if (role) return role;
+    if (userInfo?.can_create_content && userInfo.platform_role === "CREATOR") {
+      return "AUTHOR";
+    }
+  }
+
+  if (
+    userInfo?.can_create_content &&
+    userInfo.platform_role === "CREATOR" &&
+    row.status === "DRAFT"
+  ) {
+    return "AUTHOR";
+  }
+
+  return undefined;
+}

--- a/src/lib/platformAccess.test.ts
+++ b/src/lib/platformAccess.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTHOR_NOT_ACTIVE_DETAIL,
+  canWriteCms,
+  isAuthorNotActiveDetail,
+  isPathAllowedWithoutGroup,
+  needsGroupOnboardingRedirect,
+  canAccessPlanRoutes,
+  normalizePlatformRole,
+  shouldShowCmsActionsColumn,
+} from "./platformAccess";
+
+describe("platformAccess", () => {
+  it("normalizes platform roles from API strings", () => {
+    expect(normalizePlatformRole("reviewer")).toBe("REVIEWER");
+    expect(normalizePlatformRole("SUPER_ADMIN")).toBe("SUPER_ADMIN");
+    expect(normalizePlatformRole(undefined)).toBe("CREATOR");
+    expect(normalizePlatformRole("unknown")).toBe("CREATOR");
+  });
+
+  it("hides CMS actions column for reviewers", () => {
+    expect(shouldShowCmsActionsColumn("REVIEWER")).toBe(false);
+    expect(shouldShowCmsActionsColumn("reviewer")).toBe(false);
+    expect(shouldShowCmsActionsColumn("CREATOR")).toBe(true);
+  });
+
+  it("blocks plan routes for reviewers", () => {
+    expect(canAccessPlanRoutes("REVIEWER")).toBe(false);
+    expect(canAccessPlanRoutes("CREATOR")).toBe(true);
+  });
+
+  it("detects author not active detail", () => {
+    expect(isAuthorNotActiveDetail(AUTHOR_NOT_ACTIVE_DETAIL)).toBe(true);
+    expect(isAuthorNotActiveDetail("other")).toBe(false);
+  });
+
+  it("canWriteCms respects role and group", () => {
+    expect(
+      canWriteCms({
+        platform_role: "SUPER_ADMIN",
+        is_active: true,
+        has_group: false,
+      }),
+    ).toBe(true);
+    expect(
+      canWriteCms({
+        platform_role: "REVIEWER",
+        is_active: true,
+        has_group: true,
+      }),
+    ).toBe(false);
+    expect(
+      canWriteCms({
+        platform_role: "CREATOR",
+        is_active: true,
+        has_group: true,
+      }),
+    ).toBe(true);
+    expect(
+      canWriteCms({
+        platform_role: "CREATOR",
+        is_active: false,
+        has_group: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("gates routes without group for creators only", () => {
+    expect(isPathAllowedWithoutGroup("/groups")).toBe(true);
+    expect(isPathAllowedWithoutGroup("/groups/abc")).toBe(true);
+    expect(isPathAllowedWithoutGroup("/admin/authors")).toBe(true);
+    expect(isPathAllowedWithoutGroup("/dashboard")).toBe(false);
+    expect(
+      needsGroupOnboardingRedirect("/dashboard", {
+        is_active: true,
+        has_group: false,
+        platform_role: "CREATOR",
+      }),
+    ).toBe(true);
+    expect(
+      needsGroupOnboardingRedirect("/groups", {
+        is_active: true,
+        has_group: false,
+        platform_role: "CREATOR",
+      }),
+    ).toBe(false);
+    expect(
+      needsGroupOnboardingRedirect("/dashboard", {
+        is_active: true,
+        has_group: false,
+        platform_role: "SUPER_ADMIN",
+      }),
+    ).toBe(false);
+    expect(
+      needsGroupOnboardingRedirect("/tags", {
+        is_active: true,
+        has_group: false,
+        platform_role: "REVIEWER",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/platformAccess.ts
+++ b/src/lib/platformAccess.ts
@@ -100,3 +100,20 @@ export function needsGroupOnboardingRedirect(
 export function canAccessAdminAuthors(role?: PlatformRole | string): boolean {
   return isSuperAdmin(role) || isReviewer(role);
 }
+
+/** Whether dashboard group filter should load (staff-wide vs membership list). */
+export function canUseDashboardGroupFilter(
+  user?: Pick<UserInfo, "platform_role" | "has_group"> | null,
+): boolean {
+  if (!user) return false;
+  if (isSuperAdmin(user.platform_role) || isReviewer(user.platform_role)) {
+    return true;
+  }
+  return user.has_group !== false;
+}
+
+export function usesStaffWideDashboardGroupList(
+  role?: PlatformRole | string,
+): boolean {
+  return isSuperAdmin(role) || isReviewer(role);
+}

--- a/src/lib/platformAccess.ts
+++ b/src/lib/platformAccess.ts
@@ -1,0 +1,102 @@
+import type { UserInfo } from "@/hooks/useUserInfo";
+
+export type PlatformRole = "CREATOR" | "REVIEWER" | "SUPER_ADMIN";
+
+export const AUTHOR_NOT_ACTIVE_DETAIL = "Author not active";
+
+function normalizeRoleArg(
+  role?: PlatformRole | string | null,
+): string | undefined {
+  const raw = role?.toString().trim().toUpperCase();
+  return raw || undefined;
+}
+
+/** Maps API platform_role strings to a canonical role (defaults to CREATOR). */
+export function normalizePlatformRole(role?: string | null): PlatformRole {
+  const raw = normalizeRoleArg(role);
+  if (raw === "SUPER_ADMIN" || raw === "REVIEWER" || raw === "CREATOR") {
+    return raw;
+  }
+  return "CREATOR";
+}
+
+export function isSuperAdmin(role?: PlatformRole | string): boolean {
+  return normalizeRoleArg(role) === "SUPER_ADMIN";
+}
+
+export function isReviewer(role?: PlatformRole | string): boolean {
+  return normalizeRoleArg(role) === "REVIEWER";
+}
+
+/** Row menus (dashboard, series plans, tags, group members, etc.). */
+export function shouldShowCmsActionsColumn(
+  role?: PlatformRole | string,
+): boolean {
+  return !isReviewer(role);
+}
+
+/** Plan detail, edit, and create routes are not available to platform reviewers. */
+export function canAccessPlanRoutes(role?: PlatformRole | string): boolean {
+  return !isReviewer(role);
+}
+
+export function canWriteCms(
+  user?: Pick<UserInfo, "platform_role" | "is_active" | "has_group"> | null,
+): boolean {
+  if (!user?.is_active) return false;
+  if (isSuperAdmin(user.platform_role)) return true;
+  if (isReviewer(user.platform_role)) return false;
+  return Boolean(user.has_group);
+}
+
+export function isAuthorNotActiveDetail(detail: unknown): boolean {
+  if (typeof detail !== "string") return false;
+  return detail.trim().toLowerCase() === AUTHOR_NOT_ACTIVE_DETAIL.toLowerCase();
+}
+
+export function isAuthorNotActiveError(error: unknown): boolean {
+  const err = error as { response?: { data?: { detail?: unknown } } };
+  return isAuthorNotActiveDetail(err?.response?.data?.detail);
+}
+
+/** Routes allowed when a CREATOR has no group yet. */
+export const NO_GROUP_ALLOWED_PREFIXES = [
+  "/groups",
+  "/profile",
+  "/admin/authors",
+] as const;
+
+export function isPathAllowedWithoutGroup(pathname: string): boolean {
+  return NO_GROUP_ALLOWED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function needsVerifyEmailRedirect(
+  user?: Pick<UserInfo, "is_verified"> | null,
+): boolean {
+  return user != null && user.is_verified === false;
+}
+
+export function needsInactiveLogout(
+  user?: Pick<UserInfo, "is_active"> | null,
+): boolean {
+  return user != null && user.is_active === false;
+}
+
+export function needsGroupOnboardingRedirect(
+  pathname: string,
+  user?: Pick<UserInfo, "is_active" | "has_group" | "platform_role"> | null,
+): boolean {
+  if (!user?.is_active) return false;
+  if (isSuperAdmin(user.platform_role) || isReviewer(user.platform_role)) {
+    return false;
+  }
+  if (user.has_group !== false) return false;
+  return !isPathAllowedWithoutGroup(pathname);
+}
+
+/** Admin authors + auth routes for platform staff. */
+export function canAccessAdminAuthors(role?: PlatformRole | string): boolean {
+  return isSuperAdmin(role) || isReviewer(role);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,9 +23,11 @@ import Signup from "./components/auth/signup/Signup";
 import Dashboard from "./components/routes/dashboard/Dashboard";
 import Analytics from "./components/routes/analytics/Analytics";
 import CreatePlan from "./components/routes/create-plan/CreatePlan";
+import PlanNewLegacyRedirect from "./components/routes/create-plan/PlanNewLegacyRedirect";
 import CreateSeries from "./components/routes/create-series/CreateSeries";
 import SeriesDetailsPage from "./components/routes/series-details/SeriesDetailsPage";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
+import PlanRouteGuard from "./components/auth/PlanRouteGuard";
 import ResetPassword from "./components/auth/reset-password/ResetPassword.tsx";
 import PlanDetailsPage from "./components/routes/task/PlanDetailsPage.tsx";
 import Profile from "./components/routes/profile/Profile.tsx";
@@ -33,6 +35,7 @@ import Tags from "./components/routes/tags/Tags.tsx";
 import Groups from "./components/routes/groups/Groups.tsx";
 import GroupFormPage from "./components/routes/groups/GroupFormPage.tsx";
 import GroupDetailsPage from "./components/routes/groups/GroupDetailsPage.tsx";
+import AdminAuthorsPage from "./components/routes/admin-authors/AdminAuthorsPage.tsx";
 import { UserbackProvider } from "./config/userback-context.tsx";
 import { Navigate } from "react-router-dom";
 import { ROUTES } from "./routes/paths.ts";
@@ -99,7 +102,19 @@ const router = createBrowserRouter([
         path: ROUTES.planNew,
         element: (
           <ProtectedRoute>
-            <CreatePlan />
+            <PlanRouteGuard>
+              <PlanNewLegacyRedirect />
+            </PlanRouteGuard>
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "/groups/:groupId/plan/new",
+        element: (
+          <ProtectedRoute>
+            <PlanRouteGuard>
+              <CreatePlan />
+            </PlanRouteGuard>
           </ProtectedRoute>
         ),
       },
@@ -107,7 +122,9 @@ const router = createBrowserRouter([
         path: "/plan/:planId/edit",
         element: (
           <ProtectedRoute>
-            <CreatePlan />
+            <PlanRouteGuard>
+              <CreatePlan />
+            </PlanRouteGuard>
           </ProtectedRoute>
         ),
       },
@@ -115,12 +132,18 @@ const router = createBrowserRouter([
         path: "/plan/:planId",
         element: (
           <ProtectedRoute>
-            <PlanDetailsPage />
+            <PlanRouteGuard>
+              <PlanDetailsPage />
+            </PlanRouteGuard>
           </ProtectedRoute>
         ),
       },
       {
         path: ROUTES.seriesNew,
+        element: <Navigate to={ROUTES.groups} replace />,
+      },
+      {
+        path: "/groups/:groupId/series/new",
         element: (
           <ProtectedRoute>
             <CreateSeries />
@@ -196,6 +219,14 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <GroupDetailsPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: ROUTES.adminAuthors,
+        element: (
+          <ProtectedRoute>
+            <AdminAuthorsPage />
           </ProtectedRoute>
         ),
       },

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -6,9 +6,11 @@ export const ROUTES = {
   resetPassword: "/reset-password",
   verifyEmail: "/verify-email",
   dashboard: "/dashboard",
+  /** @deprecated use groupPlanNew */
   planNew: "/plan/new",
   plan: (planId: string) => `/plan/${planId}`,
   planEdit: (planId: string) => `/plan/${planId}/edit`,
+  /** @deprecated use groupSeriesNew */
   seriesNew: "/series/new",
   series: (seriesId: string) => `/series/${seriesId}`,
   seriesEdit: (seriesId: string) => `/series/${seriesId}/edit`,
@@ -19,6 +21,9 @@ export const ROUTES = {
   groupNew: "/groups/new",
   group: (groupId: string) => `/groups/${groupId}`,
   groupEdit: (groupId: string) => `/groups/${groupId}/edit`,
+  groupPlanNew: (groupId: string) => `/groups/${groupId}/plan/new`,
+  groupSeriesNew: (groupId: string) => `/groups/${groupId}/series/new`,
+  adminAuthors: "/admin/authors",
 } as const;
 
 export const AUTH_ROUTE_PATHS: readonly string[] = [

--- a/src/schema/PlanSchema.ts
+++ b/src/schema/PlanSchema.ts
@@ -10,4 +10,5 @@ export const planSchema = z.object({
   language: z.string().min(1, "Language is required"),
   start_date: z.iso.datetime().nullable().optional(),
   series_id: z.string().nullable().optional(),
+  group_id: z.string().uuid().optional(),
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -25,6 +25,23 @@ vi.mock("@tolgee/react", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useUserInfo", () => ({
+  USER_INFO_QUERY_KEY: ["userInfo"],
+  fetchUserInfo: vi.fn(),
+  useUserInfo: () => ({
+    data: {
+      id: "test-user-id",
+      email: "test@example.com",
+      platform_role: "SUPER_ADMIN",
+      is_verified: true,
+      is_active: true,
+      has_group: true,
+      can_create_content: true,
+    },
+    isLoading: false,
+  }),
+}));
+
 Object.defineProperty(global, "URL", {
   value: {
     createObjectURL: vi.fn(() => "mock-blob-url"),


### PR DESCRIPTION
## Summary

Introduces platform-level roles (`CREATOR`, `REVIEWER`, `SUPER_ADMIN`) and wires them through auth, navigation, dashboard, groups, series, plans, and tags. Reviewers get read-only CMS access; creators remain group-scoped; super admins can manage authors and transfers. Also adds plan/series content transfer between groups, an admin authors page, dashboard group filtering by role, and follow-up fixes for image URL resolution and build/type errors.

**Base branch:** `dev`  
**Compare:** `dev...feat/rbac`

## What changed

### Platform roles & access control

- Add `platformAccess` helpers (`CREATOR` / `REVIEWER` / `SUPER_ADMIN`) for route guards, CMS write access, and UI visibility.
- Add `contentPermissions` and `dashboardRowPermissions` for group-scoped actions on dashboard/series rows.
- Extend `useUserInfo` with `platform_role`, activation, verification, and group membership flags.
- **ProtectedRoute:** redirect unverified users to verify-email, inactive authors to login, creators without a group to `/groups`.
- **Login:** handle inactive-author errors and inactive redirect state.
- **PlanRouteGuard:** block `/plan/*` routes for platform reviewers.
- Relax ESLint `no-explicit-any` for legacy code paths.

### Admin authors (super admin)

- New **Authors** admin page: activation queue, suspend/activate, platform role assignment.
- `adminAuthorsApi` for list, activate, suspend, and patch platform role.
- Navbar link gated by `canAccessAdminAuthors`.

### Content transfer (plans & series)

- `transferApi` with CMS payload normalization (alternate field names, nested group objects).
- **ContentTransferDialog** and integration in `DropdownButton` for plan/series transfer requests.
- **GroupTransfersSection** for incoming/outgoing transfer management on group pages.
- Tests for transfer API normalization and group API transfer helpers.

### Dashboard

- Group filter in URL state with role-based group lists (`for_dashboard` API param).
- `useDashboardGroupFilterOptions` hook; staff see wider group lists than regular creators.
- `enrichDashboardRows` to backfill `group_id` / `series_id` when list API omits them.
- Locale-aware series titles (merged from `dev`) combined with image resolver and group enrichment.
- `resolveDashboardItemImageUrl` for `image_url`, `plan_image_url`, nested `image`, and `image_key`.
- Reviewers: hide CMS action column; read-only featured/plan links where applicable.

### Groups

- **GroupContentSection** for linked plans/series on group detail.
- Group-scoped plan/series create routes (`ROUTES.groupPlanNew`, etc.).
- Transfer ownership UI and permissions refinements.
- Invite admin section respects platform reviewer read-only rules.
- Dashboard filter tests for role-based group API behavior.

### Series & plans

- Series details: permissions via `useGroupContentPermissions`; plan reorder/feature/transfer gated by role.
- Group-scoped plan search in `PlanSearchSelector`.
- **PlanNewLegacyRedirect** for legacy plan-new URLs.
- Series/plan mappers use shared image resolver so nested API image objects render real covers (not default placeholder).

### Tags & notifications

- Tags page/table read-only for reviewers (no create/edit/delete).
- Notification bell: group-invite accept/reject via invite APIs; simplified dismiss flow.

### Tooling & tests

- New/updated tests: `platformAccess`, `contentPermissions`, `dashboardRowPermissions`, `PlanRouteGuard`, `ProtectedRoute`, transfer API, groups dashboard filter, series image mapping, dashboard API images.

## Behavioral notes

| Role | Behavior |
|------|----------|
| **CREATOR** | Full CMS within groups they belong to; onboarding redirect if no group. |
| **REVIEWER** | Read-only CMS; no plan routes; no row action menus; no tag writes. |
| **SUPER_ADMIN** | Admin authors page; broader dashboard group filter; transfer and activation controls. |

Inactive or unverified authors are blocked at login / protected routes before reaching CMS pages.

## Test plan

### Auth & onboarding
- [ ] Unverified user is redirected to verify-email.
- [ ] Inactive user sees inactive message on login and cannot access protected routes.
- [ ] Creator without a group is redirected to `/groups`.
- [ ] Active creator with a group reaches dashboard normally.

### Platform roles
- [ ] **REVIEWER:** cannot open `/plan/:id`; plan links on series details are non-navigable; CMS actions column hidden on dashboard/series tables.
- [ ] **REVIEWER:** tags page is view-only; group invite revoke disabled where applicable.
- [ ] **SUPER_ADMIN:** can open Admin Authors, activate/suspend authors, change platform roles.
- [ ] **CREATOR:** can create/edit plans and series within permitted groups.

### Dashboard
- [ ] Group filter populates correctly for creator vs staff roles.
- [ ] Filter persists in URL (`group_id` query param).
- [ ] Plan and series rows show correct cover images (including nested `image.medium` payloads).
- [ ] Series titles respect current Tolgee locale.

### Content transfer
- [ ] Initiate plan/series transfer from row actions (creator/admin).
- [ ] Incoming/outgoing transfers visible on group page; accept/reject/revoke work.
- [ ] Transfer list handles alternate API payload shapes.

### Series details
- [ ] Plan covers display correctly (not default placeholder) at `/series/:id`.
- [ ] Reorder, feature, remove, and add-plan flows respect group role and platform read-only state.

### Groups
- [ ] Group content section lists embedded plans/series.
- [ ] Ownership transfer modal available to owner only.
- [ ] Group-scoped “Add new plan” from series details uses correct group route.