### PR TITLE
feat(series): implement series creation and partial update functionality

### DIFF
--- a/src/components/routes/create-series/CreateSeries.tsx
+++ b/src/components/routes/create-series/CreateSeries.tsx
@@ -21,6 +21,7 @@ import type { LanguageCode } from "@/schema/SeriesSchema";
 import { useSeriesForm } from "@/components/routes/create-series/hooks/useSeriesForm";
 import PlanSearchSelector from "@/components/routes/create-series/components/PlanSearchSelector";
 import {
+  buildSeriesCreateBody,
   buildSeriesUpdateBody,
   getSeries,
   mapSeriesDetailToFormData,
@@ -153,15 +154,19 @@ const CreateSeries = () => {
 
   const saveSeriesMutation = useMutation({
     mutationFn: async (input: { data: SeriesFormData; featured: boolean }) => {
-      const body = buildSeriesUpdateBody(
-        input.data,
-        input.featured,
-        isNew ? groupId : undefined,
-      );
       if (isNew) {
+        const body = buildSeriesCreateBody(
+          input.data,
+          input.featured,
+          groupId,
+        );
         const created = await postSeries(body);
         return { id: String(created.id) };
       }
+      const body = buildSeriesUpdateBody(input.data, input.featured, {
+        original: mapSeriesDetailToFormData(seriesData!),
+        originalFeatured: seriesData!.featured,
+      });
       await putUpdateSeries({
         seriesId: seriesId!,
         body,

--- a/src/components/routes/create-series/api/seriesApi.test.ts
+++ b/src/components/routes/create-series/api/seriesApi.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSeriesPartialUpdateBody,
+  buildSeriesUpdateBody,
+} from "./seriesApi";
+import type { SeriesFormData } from "@/schema/SeriesSchema";
+
+const baseForm: SeriesFormData = {
+  languages: {
+    EN: { title: "Series title", description: "Original description" },
+  },
+  plans: {
+    EN: [
+      { id: "plan-a", title: "Plan A" },
+      { id: "plan-b", title: "Plan B" },
+    ],
+  },
+  image_url: "series-image-key",
+};
+
+describe("buildSeriesPartialUpdateBody", () => {
+  it("sends only metadata when description changes", () => {
+    const current: SeriesFormData = {
+      ...baseForm,
+      languages: {
+        EN: {
+          title: "Series title",
+          description: "Updated description",
+        },
+      },
+    };
+
+    const body = buildSeriesPartialUpdateBody(current, baseForm, false, false);
+
+    expect(body).toEqual({
+      metadata: [
+        {
+          language: "EN",
+          title: "Series title",
+          description: "Updated description",
+        },
+      ],
+    });
+    expect(body.plans).toBeUndefined();
+    expect(body.image_key).toBeUndefined();
+    expect(body.featured).toBeUndefined();
+  });
+
+  it("sends only plans when plan order changes", () => {
+    const current: SeriesFormData = {
+      ...baseForm,
+      plans: {
+        EN: [
+          { id: "plan-b", title: "Plan B" },
+          { id: "plan-a", title: "Plan A" },
+        ],
+      },
+    };
+
+    const body = buildSeriesPartialUpdateBody(current, baseForm, false, false);
+
+    expect(body).toEqual({
+      plans: { EN: ["plan-b", "plan-a"] },
+    });
+    expect(body.metadata).toBeUndefined();
+  });
+
+  it("sends only image_key when cover changes", () => {
+    const current: SeriesFormData = {
+      ...baseForm,
+      image_url: "new-image-key",
+    };
+
+    const body = buildSeriesPartialUpdateBody(current, baseForm, false, false);
+
+    expect(body).toEqual({ image_key: "new-image-key" });
+  });
+
+  it("sends only featured when featured flag changes", () => {
+    const body = buildSeriesPartialUpdateBody(baseForm, baseForm, true, false);
+
+    expect(body).toEqual({ featured: true });
+  });
+});
+
+describe("buildSeriesUpdateBody", () => {
+  it("returns full payload for create", () => {
+    const body = buildSeriesUpdateBody(baseForm, false, { groupId: "group-1" });
+
+    expect(body).toMatchObject({
+      metadata: [
+        {
+          language: "EN",
+          title: "Series title",
+          description: "Original description",
+        },
+      ],
+      featured: false,
+      plans: { EN: ["plan-a", "plan-b"] },
+      image_key: "series-image-key",
+      group_id: "group-1",
+    });
+  });
+
+  it("returns partial payload when original form is provided", () => {
+    const current: SeriesFormData = {
+      ...baseForm,
+      languages: {
+        EN: {
+          title: "Series title",
+          description: "Updated description",
+        },
+      },
+    };
+
+    const body = buildSeriesUpdateBody(current, false, { original: baseForm });
+
+    expect(body).toEqual({
+      metadata: [
+        {
+          language: "EN",
+          title: "Series title",
+          description: "Updated description",
+        },
+      ],
+    });
+  });
+});

--- a/src/components/routes/create-series/api/seriesApi.ts
+++ b/src/components/routes/create-series/api/seriesApi.ts
@@ -279,12 +279,95 @@ export function buildSeriesCreateBody(
   return buildSeriesWriteBody(data, featured, groupId);
 }
 
+function seriesMetadataEqual(
+  a: SeriesMetadataInput[],
+  b: SeriesMetadataInput[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].language !== b[i].language) return false;
+    if (a[i].title !== b[i].title) return false;
+    if (a[i].description !== b[i].description) return false;
+  }
+  return true;
+}
+
+function seriesPlansEqual(
+  a: Partial<Record<LanguageCode, string[]>>,
+  b: Partial<Record<LanguageCode, string[]>>,
+): boolean {
+  const codes = new Set<LanguageCode>([
+    ...(Object.keys(a) as LanguageCode[]),
+    ...(Object.keys(b) as LanguageCode[]),
+  ]);
+  for (const code of codes) {
+    const aIds = a[code] ?? [];
+    const bIds = b[code] ?? [];
+    if (aIds.length !== bIds.length) return false;
+    for (let i = 0; i < aIds.length; i++) {
+      if (aIds[i] !== bIds[i]) return false;
+    }
+  }
+  return true;
+}
+
+export function buildSeriesPartialUpdateBody(
+  current: SeriesFormData,
+  original: SeriesFormData,
+  featured: boolean,
+  originalFeatured: boolean,
+): SeriesUpdatePayload {
+  const body: SeriesUpdatePayload = {};
+
+  const currentMetadata = buildSeriesMetadata(current.languages);
+  const originalMetadata = buildSeriesMetadata(original.languages);
+  if (!seriesMetadataEqual(currentMetadata, originalMetadata)) {
+    body.metadata = currentMetadata;
+  }
+
+  const currentImageKey = current.image_url.trim();
+  const originalImageKey = original.image_url.trim();
+  if (currentImageKey !== originalImageKey && currentImageKey) {
+    body.image_key = currentImageKey;
+  }
+
+  if (featured !== originalFeatured) {
+    body.featured = featured;
+  }
+
+  const currentPlans = buildSeriesPlansJson(
+    current,
+    currentMetadata.map((m) => m.language),
+  );
+  const originalPlans = buildSeriesPlansJson(
+    original,
+    originalMetadata.map((m) => m.language),
+  );
+  if (!seriesPlansEqual(currentPlans, originalPlans)) {
+    body.plans = currentPlans;
+  }
+
+  return body;
+}
+
 export function buildSeriesUpdateBody(
   data: SeriesFormData,
   featured: boolean,
-  groupId?: string,
-): SeriesPayload {
-  return buildSeriesWriteBody(data, featured, groupId);
+  options?: {
+    groupId?: string;
+    original?: SeriesFormData;
+    originalFeatured?: boolean;
+  },
+): SeriesPayload | SeriesUpdatePayload {
+  if (!options?.original) {
+    return buildSeriesWriteBody(data, featured, options?.groupId);
+  }
+  return buildSeriesPartialUpdateBody(
+    data,
+    options.original,
+    featured,
+    options.originalFeatured ?? featured,
+  );
 }
 
 export function buildSeriesPlansPayloadFromIds(


### PR DESCRIPTION
- Added `buildSeriesCreateBody` function to construct request body for new series creation.
- Updated `saveSeriesMutation` to handle series creation and partial updates based on whether the series is new or being updated.
- Introduced helper functions to compare series metadata and plans for efficient updates.
- Enhanced `buildSeriesUpdateBody` to support partial updates with original data comparison.