### PR TITLE
Add drag-and-drop reordering for chant items in GroupChantDetailPage

### DIFF
--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -305,25 +305,7 @@ const Dashboard = () => {
           </Pecha.Select>
         </div>
       ) : null}
-      <div className="flex min-w-[180px] flex-col gap-1">
-        <span className="text-xs font-medium text-muted-foreground">Sort</span>
-        <Pecha.Select
-          value={sortValue}
-          onValueChange={() => {
-            // Backend sort is fixed; keep URL clean (omit `sort` = default).
-            replaceUrlState({ sort: null });
-          }}
-        >
-          <Pecha.SelectTrigger className="h-9 w-[200px] bg-white dark:bg-input/30">
-            <Pecha.SelectValue placeholder="Sort" />
-          </Pecha.SelectTrigger>
-          <Pecha.SelectContent>
-            <Pecha.SelectItem value="recent">
-              Recently modified
-            </Pecha.SelectItem>
-          </Pecha.SelectContent>
-        </Pecha.Select>
-      </div>
+     
       <div className="flex min-w-[160px] flex-col gap-1">
         <span className="text-xs font-medium text-muted-foreground">
           Language

--- a/src/components/routes/dashboard/Dashboard.tsx
+++ b/src/components/routes/dashboard/Dashboard.tsx
@@ -11,7 +11,6 @@ import {
   mergeDashboardUrlState,
   parseDashboardSearchParams,
   type DashboardPlanStatus,
-  type DashboardSort,
   type DashboardUrlState,
 } from "@/components/routes/dashboard/dashboardUrlState";
 import { IoMdSearch } from "react-icons/io";
@@ -266,8 +265,6 @@ const Dashboard = () => {
         ? "Create a series to see it listed here."
         : "Try clearing search or add new plans and series.";
 
-  const sortValue: DashboardSort = urlState.sort ?? "recent";
-
   const groupFilterValue = urlState.groupId ?? "all";
 
   const filterBar = (
@@ -305,7 +302,7 @@ const Dashboard = () => {
           </Pecha.Select>
         </div>
       ) : null}
-     
+
       <div className="flex min-w-[160px] flex-col gap-1">
         <span className="text-xs font-medium text-muted-foreground">
           Language

--- a/src/components/routes/dashboard/DashboardContentTable.tsx
+++ b/src/components/routes/dashboard/DashboardContentTable.tsx
@@ -11,7 +11,6 @@ import type {
 } from "./dashboardTable";
 import {
   DASHBOARD_TABLE_ICON_BTN,
-  formatRowModified,
   isMockDashboardId,
 } from "./dashboardTable";
 import { ROUTES } from "@/routes/paths";
@@ -73,7 +72,7 @@ export function DashboardContentTable({
         row.kind === "plan" ? ROUTES.plan(row.id) : ROUTES.series(row.id);
       const canOpenTitle =
         row.kind === "series" || canAccessPlanRoutes(platformRole);
-      const modifiedDisplay = formatRowModified(row);
+   
       const canToggleFeatured =
         row.kind === "series" ||
         (row.kind === "plan" && !isMockDashboardId(row.id));
@@ -144,9 +143,7 @@ export function DashboardContentTable({
           <Pecha.TableCell className="text-sm text-center">
             {row.enrolled}
           </Pecha.TableCell>
-          <Pecha.TableCell className="text-sm text-center">
-            {modifiedDisplay}
-          </Pecha.TableCell>
+        
           <Pecha.TableCell className="text-center">
             {canToggleFeatured && canFeature && !platformReadOnly ? (
               <Pecha.Button
@@ -227,9 +224,7 @@ export function DashboardContentTable({
           <Pecha.TableHead className="w-[100px] font-bold text-center">
             {t("studio.dashboard.plan_used")}
           </Pecha.TableHead>
-          <Pecha.TableHead className="w-[130px] font-bold text-center">
-            Date Modified
-          </Pecha.TableHead>
+         
           <Pecha.TableHead className="w-[72px] font-bold text-center">
             Featured
           </Pecha.TableHead>

--- a/src/components/routes/groups/GroupChantDetailPage.tsx
+++ b/src/components/routes/groups/GroupChantDetailPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   Link,
   useNavigate,
@@ -6,7 +5,24 @@ import {
   useParams,
 } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { CSS } from "@dnd-kit/utilities";
 import { IoMdArrowBack, IoMdTrash, IoMdAdd, IoMdClose } from "react-icons/io";
+import { PiDotsSixVertical } from "react-icons/pi";
 import { toast } from "sonner";
 import { Pecha } from "@/components/ui/shadimport";
 import { Button } from "@/components/ui/atoms/button";
@@ -23,6 +39,71 @@ import {
 } from "./api/chantsApi";
 import FkMultiSearchSelector from "./components/FkMultiSearchSelector";
 import type { FkOption } from "./components/FkMultiSearchSelector";
+import { useChantItemReorder } from "./hooks/useChantItemReorder";
+
+function SortableChantItemRow({
+  item,
+  index,
+  canWrite,
+  canReorder,
+  onRemove,
+}: {
+  readonly item: ChantCollectionItemDTO;
+  readonly index: number;
+  readonly canWrite: boolean;
+  readonly canReorder: boolean;
+  readonly onRemove: (item: ChantCollectionItemDTO) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id, disabled: !canReorder });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <Pecha.TableRow ref={setNodeRef} style={style} {...attributes}>
+      {canWrite ? (
+        <Pecha.TableCell className="w-10">
+          <button
+            type="button"
+            className="shrink-0 rounded p-1 text-muted-foreground hover:text-foreground touch-none disabled:cursor-not-allowed disabled:opacity-30"
+            aria-label={`Reorder ${item.title}`}
+            disabled={!canReorder}
+            {...listeners}
+          >
+            <PiDotsSixVertical className="h-4 w-4" />
+          </button>
+        </Pecha.TableCell>
+      ) : null}
+      <Pecha.TableCell className="text-muted-foreground">{index + 1}</Pecha.TableCell>
+      <Pecha.TableCell className="font-medium">{item.title}</Pecha.TableCell>
+      <Pecha.TableCell>{item.language ?? "—"}</Pecha.TableCell>
+      <Pecha.TableCell>{item.type ?? "—"}</Pecha.TableCell>
+      {canWrite ? (
+        <Pecha.TableCell className="text-right">
+          <Pecha.Button
+            variant="outline"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            onClick={() => onRemove(item)}
+            aria-label={`Remove ${item.title}`}
+          >
+            <IoMdTrash className="h-4 w-4" />
+          </Pecha.Button>
+        </Pecha.TableCell>
+      ) : null}
+    </Pecha.TableRow>
+  );
+}
 
 const GroupChantDetailPage = () => {
   const { groupId, collectionId } = useParams<{
@@ -50,6 +131,17 @@ const GroupChantDetailPage = () => {
     enabled: Boolean(groupId) && Boolean(collectionId),
     refetchOnWindowFocus: false,
   });
+
+  const { displayItems, canReorder, handleReorder } = useChantItemReorder(
+    groupId,
+    collectionId,
+    data?.items,
+    canWrite,
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  );
 
   const deleteItemMutation = useMutation({
     mutationFn: (itemId: string) =>
@@ -90,7 +182,6 @@ const GroupChantDetailPage = () => {
       return;
     }
 
-    // Check for duplicates
     const existingTextIds = new Set(
       data?.items.map((item) => item.text_id) ?? [],
     );
@@ -99,11 +190,11 @@ const GroupChantDetailPage = () => {
     );
 
     if (duplicates.length > 0) {
-      toast.error(
+      const duplicateMessage =
         duplicates.length === 1
           ? `"${duplicates[0].title}" is already in this collection`
-          : `${duplicates.length} chant${duplicates.length > 1 ? "s are" : " is"} already in this collection`,
-      );
+          : `${duplicates.length} chants are already in this collection`;
+      toast.error(duplicateMessage);
       return;
     }
 
@@ -114,6 +205,19 @@ const GroupChantDetailPage = () => {
     setIsEditMode(false);
     setSelectedRecitations([]);
   };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      handleReorder(String(active.id), String(over.id));
+    }
+  };
+
+  const addButtonLabel = (() => {
+    if (addItemsMutation.isPending) return "Adding...";
+    const count = selectedRecitations.length;
+    return `Add ${count} ${count === 1 ? "Chant" : "Chants"}`;
+  })();
 
   const chantsListPath = groupId ? ROUTES.groupChants(groupId) : ROUTES.groups;
 
@@ -152,7 +256,7 @@ const GroupChantDetailPage = () => {
           </Button>
           <h1 className="text-xl font-bold">{data.name}</h1>
         </div>
-        {canWrite && !isEditMode ? (
+        {canWrite && !isEditMode && (
           <Button
             variant="default"
             size="sm"
@@ -161,11 +265,12 @@ const GroupChantDetailPage = () => {
           >
             <IoMdAdd className="w-4 h-4" /> Add Chants
           </Button>
-        ) : canWrite && isEditMode ? (
+        )}
+        {canWrite && isEditMode && (
           <Button variant="outline" size="sm" onClick={handleCancelEdit}>
             <IoMdClose className="w-4 h-4" /> Cancel
           </Button>
-        ) : null}
+        )}
       </div>
 
       {data.img_url ? (
@@ -177,7 +282,9 @@ const GroupChantDetailPage = () => {
       ) : null}
 
       <div className="space-y-4">
-        <h2 className="text-lg font-semibold">Items ({data.items.length})</h2>
+        <h2 className="text-lg font-semibold">
+          Items ({displayItems.length})
+        </h2>
 
         {isEditMode && (
           <div className="rounded-lg border border-blue-900 bg-blue-900/5 p-4 space-y-4">
@@ -200,60 +307,56 @@ const GroupChantDetailPage = () => {
                 }
                 className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90"
               >
-                {addItemsMutation.isPending
-                  ? "Adding..."
-                  : `Add ${selectedRecitations.length} Chant${selectedRecitations.length === 1 ? "" : "s"}`}
+                {addButtonLabel}
               </Pecha.Button>
             </div>
           </div>
         )}
 
-        {data.items.length === 0 ? (
+        {displayItems.length === 0 ? (
           <p className="text-muted-foreground">No items in this collection.</p>
         ) : (
           <div className="rounded-lg border">
-            <Pecha.Table>
-              <Pecha.TableHeader>
-                <Pecha.TableRow>
-                  <Pecha.TableHead className="w-12">#</Pecha.TableHead>
-                  <Pecha.TableHead>Title</Pecha.TableHead>
-                  <Pecha.TableHead>Language</Pecha.TableHead>
-                  <Pecha.TableHead>Type</Pecha.TableHead>
-                  {canWrite ? (
-                    <Pecha.TableHead className="text-right">
-                      Actions
-                    </Pecha.TableHead>
-                  ) : null}
-                </Pecha.TableRow>
-              </Pecha.TableHeader>
-              <Pecha.TableBody>
-                {data.items.map((item, index) => (
-                  <Pecha.TableRow key={item.id}>
-                    <Pecha.TableCell className="text-muted-foreground">
-                      {index + 1}
-                    </Pecha.TableCell>
-                    <Pecha.TableCell className="font-medium">
-                      {item.title}
-                    </Pecha.TableCell>
-                    <Pecha.TableCell>{item.language ?? "—"}</Pecha.TableCell>
-                    <Pecha.TableCell>{item.type ?? "—"}</Pecha.TableCell>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+              modifiers={[restrictToVerticalAxis]}
+            >
+              <Pecha.Table>
+                <Pecha.TableHeader>
+                  <Pecha.TableRow>
+                    {canWrite ? <Pecha.TableHead className="w-10" /> : null}
+                    <Pecha.TableHead className="w-12">#</Pecha.TableHead>
+                    <Pecha.TableHead>Title</Pecha.TableHead>
+                    <Pecha.TableHead>Language</Pecha.TableHead>
+                    <Pecha.TableHead>Type</Pecha.TableHead>
                     {canWrite ? (
-                      <Pecha.TableCell className="text-right">
-                        <Pecha.Button
-                          variant="outline"
-                          size="sm"
-                          className="text-destructive hover:text-destructive"
-                          onClick={() => setPendingDeleteItem(item)}
-                          aria-label={`Remove ${item.title}`}
-                        >
-                          <IoMdTrash className="h-4 w-4" />
-                        </Pecha.Button>
-                      </Pecha.TableCell>
+                      <Pecha.TableHead className="text-right">
+                        Actions
+                      </Pecha.TableHead>
                     ) : null}
                   </Pecha.TableRow>
-                ))}
-              </Pecha.TableBody>
-            </Pecha.Table>
+                </Pecha.TableHeader>
+                <SortableContext
+                  items={displayItems.map((item) => item.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <Pecha.TableBody>
+                    {displayItems.map((item, index) => (
+                      <SortableChantItemRow
+                        key={item.id}
+                        item={item}
+                        index={index}
+                        canWrite={canWrite}
+                        canReorder={canReorder}
+                        onRemove={setPendingDeleteItem}
+                      />
+                    ))}
+                  </Pecha.TableBody>
+                </SortableContext>
+              </Pecha.Table>
+            </DndContext>
           </div>
         )}
       </div>

--- a/src/components/routes/groups/GroupChantDetailPage.tsx
+++ b/src/components/routes/groups/GroupChantDetailPage.tsx
@@ -84,7 +84,9 @@ function SortableChantItemRow({
           </button>
         </Pecha.TableCell>
       ) : null}
-      <Pecha.TableCell className="text-muted-foreground">{index + 1}</Pecha.TableCell>
+      <Pecha.TableCell className="text-muted-foreground">
+        {index + 1}
+      </Pecha.TableCell>
       <Pecha.TableCell className="font-medium">{item.title}</Pecha.TableCell>
       <Pecha.TableCell>{item.language ?? "—"}</Pecha.TableCell>
       <Pecha.TableCell>{item.type ?? "—"}</Pecha.TableCell>
@@ -282,9 +284,7 @@ const GroupChantDetailPage = () => {
       ) : null}
 
       <div className="space-y-4">
-        <h2 className="text-lg font-semibold">
-          Items ({displayItems.length})
-        </h2>
+        <h2 className="text-lg font-semibold">Items ({displayItems.length})</h2>
 
         {isEditMode && (
           <div className="rounded-lg border border-blue-900 bg-blue-900/5 p-4 space-y-4">

--- a/src/components/routes/groups/hooks/useChantItemReorder.ts
+++ b/src/components/routes/groups/hooks/useChantItemReorder.ts
@@ -48,8 +48,7 @@ export const useChantItemReorder = (
     },
   });
 
-  const displayItems =
-    orderedItems.length > 0 ? orderedItems : (items ?? []);
+  const displayItems = orderedItems.length > 0 ? orderedItems : (items ?? []);
   const canReorder = canWrite && displayItems.length > 1;
 
   const handleReorder = (activeId: string, overId: string) => {

--- a/src/components/routes/groups/hooks/useChantItemReorder.ts
+++ b/src/components/routes/groups/hooks/useChantItemReorder.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import { reorderArray } from "@/lib/utils";
+import {
+  reorderChantItems,
+  type ChantCollectionItemDTO,
+} from "../api/chantsApi";
+
+const sortByDisplayOrder = (items: ChantCollectionItemDTO[]) =>
+  [...items].sort((a, b) => a.display_order - b.display_order);
+
+export const useChantItemReorder = (
+  groupId: string | undefined,
+  collectionId: string | undefined,
+  items: ChantCollectionItemDTO[] | undefined,
+  canWrite: boolean,
+) => {
+  const queryClient = useQueryClient();
+  const [orderedItems, setOrderedItems] = useState<ChantCollectionItemDTO[]>(
+    [],
+  );
+
+  useEffect(() => {
+    if (items) {
+      setOrderedItems(sortByDisplayOrder(items));
+    }
+  }, [items]);
+
+  const reorderMutation = useMutation({
+    mutationFn: (itemIds: string[]) =>
+      reorderChantItems(groupId!, collectionId!, itemIds),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(
+        ["cms-chant-collection", groupId, collectionId],
+        updated,
+      );
+      setOrderedItems(sortByDisplayOrder(updated.items));
+    },
+    onError: (err) => {
+      if (items) {
+        setOrderedItems(sortByDisplayOrder(items));
+      }
+      toast.error("Failed to reorder chants", {
+        description: getApiErrorMessage(err),
+      });
+    },
+  });
+
+  const displayItems =
+    orderedItems.length > 0 ? orderedItems : (items ?? []);
+  const canReorder = canWrite && displayItems.length > 1;
+
+  const handleReorder = (activeId: string, overId: string) => {
+    if (!canReorder || activeId === overId) return;
+
+    const next = reorderArray(displayItems, activeId, overId);
+    if (!next) return;
+
+    setOrderedItems(next);
+    reorderMutation.mutate(next.map((item) => item.id));
+  };
+
+  return {
+    displayItems,
+    canReorder,
+    handleReorder,
+  };
+};

--- a/src/components/ui/molecules/auth-button/AuthButton.tsx
+++ b/src/components/ui/molecules/auth-button/AuthButton.tsx
@@ -1,36 +1,118 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { IoChevronBack, IoNotificationsOutline, IoPersonOutline } from "react-icons/io5";
 import { useAuth } from "@/config/auth-context";
 import { NO_PROFILE_IMAGE } from "@/lib/constant";
-import { Link } from "react-router-dom";
 import { ROUTES } from "@/routes/paths";
 import { useUserInfo } from "@/hooks/useUserInfo";
+import { Pecha } from "@/components/ui/shadimport";
+import {
+  NotificationsPanel,
+  useUnreadNotifications,
+} from "@/components/ui/molecules/notification-bell/NotificationsPanel";
+
+type MenuView = "options" | "notifications";
 
 const AuthButton = () => {
   const { isLoggedIn } = useAuth();
   const { data: userInfo } = useUserInfo();
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<MenuView>("options");
+  const { data: notificationsData } = useUnreadNotifications();
+  const unreadCount = notificationsData?.total ?? 0;
 
-  if (isLoggedIn) {
-    return (
-      <Link to={ROUTES.profile}>
-        <div className="flex items-center font-dynamic gap-2">
-          <img
-            src={
-              userInfo?.image?.thumbnail ||
-              userInfo?.image_url ||
-              NO_PROFILE_IMAGE
-            }
-            alt="user"
-            className="hidden w-10 h-10 object-cover md:block rounded-full"
-          />
-          <div className="md:flex hidden flex-col">
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setView("options");
+  };
+
+  if (!isLoggedIn) return null;
+
+  return (
+    <Pecha.DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <Pecha.DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center font-dynamic gap-2 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Account menu"
+        >
+          <div className="relative">
+            <img
+              src={
+                userInfo?.image?.thumbnail ||
+                userInfo?.image_url ||
+                NO_PROFILE_IMAGE
+              }
+              alt="user"
+              className="hidden w-10 h-10 object-cover md:block rounded-full"
+            />
+            {unreadCount > 0 && (
+              <span className="absolute -top-0.5 -right-0.5 hidden md:flex h-4 min-w-4 items-center justify-center rounded-full bg-[#A51C21] px-1 text-[10px] font-medium text-white">
+                {unreadCount > 9 ? "9+" : unreadCount}
+              </span>
+            )}
+          </div>
+          <div className="md:flex hidden flex-col text-left">
             <span className="text-sm font-medium">
               {userInfo?.firstname} {userInfo?.lastname}
             </span>
             <span className="text-xs text-[#8a8a8a]">{userInfo?.email}</span>
           </div>
-        </div>
-      </Link>
-    );
-  }
+        </button>
+      </Pecha.DropdownMenuTrigger>
+
+      <Pecha.DropdownMenuContent
+        align="end"
+        className={
+          view === "notifications"
+            ? "w-auto max-h-none overflow-visible p-0"
+            : "min-w-[12rem]"
+        }
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
+        {view === "options" ? (
+          <>
+            <Pecha.DropdownMenuItem asChild>
+              <Link to={ROUTES.profile} className="cursor-pointer">
+                <IoPersonOutline className="size-4" />
+                Profile
+              </Link>
+            </Pecha.DropdownMenuItem>
+            <Pecha.DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={(event) => {
+                event.preventDefault();
+                setView("notifications");
+              }}
+            >
+              <IoNotificationsOutline className="size-4" />
+              Notifications
+              {unreadCount > 0 ? (
+                <span className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-[#A51C21] px-1.5 text-[10px] font-medium text-white">
+                  {unreadCount > 9 ? "9+" : unreadCount}
+                </span>
+              ) : null}
+            </Pecha.DropdownMenuItem>
+          </>
+        ) : (
+          <div>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 border-b px-3 py-2 text-sm font-medium hover:bg-accent"
+              onClick={() => setView("options")}
+            >
+              <IoChevronBack className="size-4" />
+              Notifications
+            </button>
+            <NotificationsPanel
+              showHeader={false}
+              onRequestClose={() => setOpen(false)}
+            />
+          </div>
+        )}
+      </Pecha.DropdownMenuContent>
+    </Pecha.DropdownMenu>
+  );
 };
 
 export default AuthButton;

--- a/src/components/ui/molecules/nav-bar/Navbar.tsx
+++ b/src/components/ui/molecules/nav-bar/Navbar.tsx
@@ -13,7 +13,6 @@ import {
   TooltipTrigger,
 } from "../../atoms/tooltip";
 import AuthAvatar from "@/components/ui/molecules/auth-avatar/AuthAvatar";
-import NotificationBell from "@/components/ui/molecules/notification-bell/NotificationBell";
 import VerseOfDayButton from "@/components/routes/verse-of-day/VerseOfDayButton";
 import { useUserInfo } from "@/hooks/useUserInfo";
 import { canAccessAdminAuthors } from "@/lib/platformAccess";
@@ -140,7 +139,6 @@ const Navbar = () => {
                 </TooltipContent>
               </Tooltip>
             ))}
-            <NotificationBell />
             <VerseOfDayButton />
           </div>
         </div>

--- a/src/components/ui/molecules/notification-bell/NotificationBell.tsx
+++ b/src/components/ui/molecules/notification-bell/NotificationBell.tsx
@@ -1,142 +1,21 @@
 import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { IoClose, IoNotificationsOutline } from "react-icons/io5";
-import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
+import { IoNotificationsOutline } from "react-icons/io5";
 import { Pecha } from "@/components/ui/shadimport";
-import { Button } from "@/components/ui/atoms/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/atoms/tooltip";
-import { getApiErrorMessage } from "@/lib/apiErrors";
-import { ROUTES } from "@/routes/paths";
 import {
-  acceptGroupInvite,
-  rejectGroupInvite,
-} from "@/components/routes/groups/api/groupsApi";
-import {
-  acceptTransferRequest,
-  rejectTransferRequest,
-} from "@/components/routes/content-transfer/api/transferApi";
-import {
-  fetchNotifications,
-  getTransferNotificationTargetGroupId,
-  isContentTransferNotification,
-  isGroupInviteNotification,
-  markNotificationRead,
-  type NotificationDTO,
-} from "@/components/routes/notifications/api/notificationsApi";
+  NotificationsPanel,
+  useUnreadNotifications,
+} from "./NotificationsPanel";
 
 const NotificationBell = () => {
-  const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [open, setOpen] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(false);
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["cms-notifications", { unread_only: true }],
-    queryFn: () => fetchNotifications({ unread_only: true, limit: 30 }),
-    refetchInterval: 60_000,
-    refetchOnWindowFocus: true,
-  });
-
+  const { data } = useUnreadNotifications();
   const unreadCount = data?.total ?? 0;
-
-  const invalidateNotifications = () => {
-    queryClient.invalidateQueries({ queryKey: ["cms-notifications"] });
-    queryClient.invalidateQueries({ queryKey: ["cms-my-group-invites"] });
-    queryClient.invalidateQueries({ queryKey: ["cms-groups"] });
-  };
-
-  const dismissMutation = useMutation({
-    mutationFn: (notificationId: string) =>
-      markNotificationRead(notificationId),
-    onSuccess: () => invalidateNotifications(),
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const inviteActionMutation = useMutation({
-    mutationFn: async ({
-      inviteId,
-      action,
-    }: {
-      inviteId: string;
-      action: "accept" | "reject";
-    }) => {
-      if (action === "accept") {
-        return acceptGroupInvite(inviteId);
-      }
-      await rejectGroupInvite(inviteId);
-      return null;
-    },
-    onSuccess: (group, { action }) => {
-      if (action === "accept") {
-        toast.success("Invitation accepted");
-        setOpen(false);
-        if (group) {
-          navigate(ROUTES.group(group.id));
-        }
-      } else {
-        toast.success("Invitation declined");
-      }
-      invalidateNotifications();
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const handleInviteAction = (
-    notification: NotificationDTO,
-    action: "accept" | "reject",
-  ) => {
-    const inviteId = notification.reference_id;
-    if (!inviteId) {
-      toast.error("Invalid invitation notification");
-      return;
-    }
-    inviteActionMutation.mutate({ inviteId, action });
-  };
-
-  const transferActionMutation = useMutation({
-    mutationFn: async ({
-      requestId,
-      action,
-    }: {
-      requestId: string;
-      action: "accept" | "reject";
-    }) => {
-      if (action === "accept") {
-        return acceptTransferRequest(requestId);
-      }
-      await rejectTransferRequest(requestId);
-      return null;
-    },
-    onSuccess: (_data, { action }) => {
-      toast.success(
-        action === "accept" ? "Transfer accepted" : "Transfer rejected",
-      );
-      invalidateNotifications();
-      queryClient.invalidateQueries({ queryKey: ["transfer-requests"] });
-      queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
-    },
-    onError: (err) => toast.error(getApiErrorMessage(err)),
-  });
-
-  const handleTransferAction = (
-    notification: NotificationDTO,
-    action: "accept" | "reject",
-  ) => {
-    const requestId = notification.reference_id;
-    if (!requestId) {
-      toast.error("Invalid transfer notification");
-      return;
-    }
-    transferActionMutation.mutate({ requestId, action });
-  };
-
-  const invitePending =
-    inviteActionMutation.isPending || transferActionMutation.isPending;
 
   const handleMenuOpenChange = (next: boolean) => {
     setOpen(next);
@@ -168,129 +47,10 @@ const NotificationBell = () => {
       <Pecha.DropdownMenuContent
         side="right"
         align="start"
-        className="w-80 max-h-[min(24rem,70vh)] overflow-auto p-0"
+        className="w-auto max-h-none overflow-visible p-0"
         onCloseAutoFocus={(event) => event.preventDefault()}
       >
-        <div className="border-b px-3 py-2 font-medium text-sm">
-          Notifications
-        </div>
-        {isLoading ? (
-          <p className="px-3 py-4 text-sm text-muted-foreground">Loading…</p>
-        ) : !data?.notifications.length ? (
-          <p className="px-3 py-4 text-sm text-muted-foreground">
-            No unread notifications
-          </p>
-        ) : (
-          <ul className="divide-y">
-            {data.notifications.map((notification) => (
-              <li key={notification.id} className="relative px-3 py-3 pr-9">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="absolute top-2 right-1 h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
-                  aria-label="Dismiss notification"
-                  disabled={invitePending || dismissMutation.isPending}
-                  onClick={() => dismissMutation.mutate(notification.id)}
-                >
-                  <IoClose className="h-4 w-4" />
-                </Button>
-                <div className="space-y-2">
-                  <p className="text-sm font-medium leading-snug pr-1">
-                    {notification.title}
-                  </p>
-                  {notification.description && (
-                    <p className="text-xs text-muted-foreground">
-                      {notification.description}
-                    </p>
-                  )}
-                  {isGroupInviteNotification(notification) && (
-                    <div className="flex flex-wrap gap-2">
-                      <Button
-                        type="button"
-                        size="sm"
-                        className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90 h-7 text-xs"
-                        disabled={invitePending}
-                        onClick={() =>
-                          handleInviteAction(notification, "accept")
-                        }
-                      >
-                        {inviteActionMutation.isPending &&
-                        inviteActionMutation.variables?.action === "accept"
-                          ? "Accepting…"
-                          : "Accept"}
-                      </Button>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="h-7 text-xs"
-                        disabled={invitePending}
-                        onClick={() =>
-                          handleInviteAction(notification, "reject")
-                        }
-                      >
-                        {inviteActionMutation.isPending &&
-                        inviteActionMutation.variables?.action === "reject"
-                          ? "Declining…"
-                          : "Reject"}
-                      </Button>
-                    </div>
-                  )}
-                  {isContentTransferNotification(notification) && (
-                    <div className="flex flex-col gap-2">
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          type="button"
-                          size="sm"
-                          className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90 h-7 text-xs"
-                          disabled={invitePending}
-                          onClick={() =>
-                            handleTransferAction(notification, "accept")
-                          }
-                        >
-                          Accept
-                        </Button>
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="outline"
-                          className="h-7 text-xs"
-                          disabled={invitePending}
-                          onClick={() =>
-                            handleTransferAction(notification, "reject")
-                          }
-                        >
-                          Reject
-                        </Button>
-                      </div>
-                      {getTransferNotificationTargetGroupId(notification) ? (
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="link"
-                          className="h-auto p-0 text-xs text-[#A51C21]"
-                          onClick={() => {
-                            setOpen(false);
-                            navigate(
-                              ROUTES.groupTransfers(
-                                getTransferNotificationTargetGroupId(
-                                  notification,
-                                )!,
-                              ),
-                            );
-                          }}
-                        >
-                          View on group page
-                        </Button>
-                      ) : null}
-                    </div>
-                  )}
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
+        <NotificationsPanel onRequestClose={() => setOpen(false)} />
       </Pecha.DropdownMenuContent>
     </Pecha.DropdownMenu>
   );

--- a/src/components/ui/molecules/notification-bell/NotificationsPanel.tsx
+++ b/src/components/ui/molecules/notification-bell/NotificationsPanel.tsx
@@ -1,0 +1,268 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { IoClose } from "react-icons/io5";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/atoms/button";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import { ROUTES } from "@/routes/paths";
+import {
+  acceptGroupInvite,
+  rejectGroupInvite,
+} from "@/components/routes/groups/api/groupsApi";
+import {
+  acceptTransferRequest,
+  rejectTransferRequest,
+} from "@/components/routes/content-transfer/api/transferApi";
+import {
+  fetchNotifications,
+  getTransferNotificationTargetGroupId,
+  isContentTransferNotification,
+  isGroupInviteNotification,
+  markNotificationRead,
+  type NotificationDTO,
+} from "@/components/routes/notifications/api/notificationsApi";
+
+interface NotificationsPanelProps {
+  onRequestClose?: () => void;
+  /** Show the "Notifications" header row (default true). */
+  showHeader?: boolean;
+}
+
+export function useUnreadNotifications() {
+  return useQuery({
+    queryKey: ["cms-notifications", { unread_only: true }],
+    queryFn: () => fetchNotifications({ unread_only: true, limit: 30 }),
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function NotificationsPanel({
+  onRequestClose,
+  showHeader = true,
+}: NotificationsPanelProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useUnreadNotifications();
+
+  const invalidateNotifications = () => {
+    queryClient.invalidateQueries({ queryKey: ["cms-notifications"] });
+    queryClient.invalidateQueries({ queryKey: ["cms-my-group-invites"] });
+    queryClient.invalidateQueries({ queryKey: ["cms-groups"] });
+  };
+
+  const dismissMutation = useMutation({
+    mutationFn: (notificationId: string) =>
+      markNotificationRead(notificationId),
+    onSuccess: () => invalidateNotifications(),
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const inviteActionMutation = useMutation({
+    mutationFn: async ({
+      inviteId,
+      action,
+    }: {
+      inviteId: string;
+      action: "accept" | "reject";
+    }) => {
+      if (action === "accept") {
+        return acceptGroupInvite(inviteId);
+      }
+      await rejectGroupInvite(inviteId);
+      return null;
+    },
+    onSuccess: (group, { action }) => {
+      if (action === "accept") {
+        toast.success("Invitation accepted");
+        onRequestClose?.();
+        if (group) {
+          navigate(ROUTES.group(group.id));
+        }
+      } else {
+        toast.success("Invitation declined");
+      }
+      invalidateNotifications();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const handleInviteAction = (
+    notification: NotificationDTO,
+    action: "accept" | "reject",
+  ) => {
+    const inviteId = notification.reference_id;
+    if (!inviteId) {
+      toast.error("Invalid invitation notification");
+      return;
+    }
+    inviteActionMutation.mutate({ inviteId, action });
+  };
+
+  const transferActionMutation = useMutation({
+    mutationFn: async ({
+      requestId,
+      action,
+    }: {
+      requestId: string;
+      action: "accept" | "reject";
+    }) => {
+      if (action === "accept") {
+        return acceptTransferRequest(requestId);
+      }
+      await rejectTransferRequest(requestId);
+      return null;
+    },
+    onSuccess: (_data, { action }) => {
+      toast.success(
+        action === "accept" ? "Transfer accepted" : "Transfer rejected",
+      );
+      invalidateNotifications();
+      queryClient.invalidateQueries({ queryKey: ["transfer-requests"] });
+      queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const handleTransferAction = (
+    notification: NotificationDTO,
+    action: "accept" | "reject",
+  ) => {
+    const requestId = notification.reference_id;
+    if (!requestId) {
+      toast.error("Invalid transfer notification");
+      return;
+    }
+    transferActionMutation.mutate({ requestId, action });
+  };
+
+  const invitePending =
+    inviteActionMutation.isPending || transferActionMutation.isPending;
+
+  return (
+    <div className="w-80 max-h-[min(24rem,70vh)] overflow-auto">
+      {showHeader ? (
+        <div className="border-b px-3 py-2 font-medium text-sm">
+          Notifications
+        </div>
+      ) : null}
+      {isLoading ? (
+        <p className="px-3 py-4 text-sm text-muted-foreground">Loading…</p>
+      ) : !data?.notifications.length ? (
+        <p className="px-3 py-4 text-sm text-muted-foreground">
+          No unread notifications
+        </p>
+      ) : (
+        <ul className="divide-y">
+          {data.notifications.map((notification) => (
+            <li key={notification.id} className="relative px-3 py-3 pr-9">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="absolute top-2 right-1 h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+                aria-label="Dismiss notification"
+                disabled={invitePending || dismissMutation.isPending}
+                onClick={() => dismissMutation.mutate(notification.id)}
+              >
+                <IoClose className="h-4 w-4" />
+              </Button>
+              <div className="space-y-2">
+                <p className="text-sm font-medium leading-snug pr-1">
+                  {notification.title}
+                </p>
+                {notification.description && (
+                  <p className="text-xs text-muted-foreground">
+                    {notification.description}
+                  </p>
+                )}
+                {isGroupInviteNotification(notification) && (
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90 h-7 text-xs"
+                      disabled={invitePending}
+                      onClick={() =>
+                        handleInviteAction(notification, "accept")
+                      }
+                    >
+                      {inviteActionMutation.isPending &&
+                      inviteActionMutation.variables?.action === "accept"
+                        ? "Accepting…"
+                        : "Accept"}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="h-7 text-xs"
+                      disabled={invitePending}
+                      onClick={() =>
+                        handleInviteAction(notification, "reject")
+                      }
+                    >
+                      {inviteActionMutation.isPending &&
+                      inviteActionMutation.variables?.action === "reject"
+                        ? "Declining…"
+                        : "Reject"}
+                    </Button>
+                  </div>
+                )}
+                {isContentTransferNotification(notification) && (
+                  <div className="flex flex-col gap-2">
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90 h-7 text-xs"
+                        disabled={invitePending}
+                        onClick={() =>
+                          handleTransferAction(notification, "accept")
+                        }
+                      >
+                        Accept
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-xs"
+                        disabled={invitePending}
+                        onClick={() =>
+                          handleTransferAction(notification, "reject")
+                        }
+                      >
+                        Reject
+                      </Button>
+                    </div>
+                    {getTransferNotificationTargetGroupId(notification) ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="link"
+                        className="h-auto p-0 text-xs text-[#A51C21]"
+                        onClick={() => {
+                          onRequestClose?.();
+                          navigate(
+                            ROUTES.groupTransfers(
+                              getTransferNotificationTargetGroupId(
+                                notification,
+                              )!,
+                            ),
+                          );
+                        }}
+                      >
+                        View on group page
+                      </Button>
+                    ) : null}
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Introduced SortableChantItemRow component for handling drag-and-drop functionality.
- Implemented useChantItemReorder hook to manage item reordering logic.
- Updated GroupChantDetailPage to utilize new reordering features and display items accordingly.
- Enhanced user feedback for duplicate chant additions and improved button labels.