### PR TITLE
Add accumulator presets functionality

### DIFF
--- a/src/components/routes/accumulator-presets/AccumulatorPresetsPage.tsx
+++ b/src/components/routes/accumulator-presets/AccumulatorPresetsPage.tsx
@@ -114,9 +114,7 @@ const AccumulatorPresetsPage = () => {
     }
   };
 
-  const totalPages = presetsData
-    ? Math.ceil(presetsData.total / PAGE_SIZE)
-    : 1;
+  const totalPages = presetsData ? Math.ceil(presetsData.total / PAGE_SIZE) : 1;
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
 
   return (

--- a/src/components/routes/accumulator-presets/AccumulatorPresetsPage.tsx
+++ b/src/components/routes/accumulator-presets/AccumulatorPresetsPage.tsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { IoMdAdd, IoMdSearch } from "react-icons/io";
+import { useDebounce } from "use-debounce";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Pecha } from "@/components/ui/shadimport";
+import { Button } from "@/components/ui/atoms/button";
+import AuthButton from "@/components/ui/molecules/auth-button/AuthButton";
+import { Pagination } from "@/components/ui/molecules/pagination/Pagination";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import { useUserInfo } from "@/hooks/useUserInfo";
+import { shouldShowCmsActionsColumn } from "@/lib/platformAccess";
+import {
+  createAccumulatorPreset,
+  deleteAccumulatorPreset,
+  fetchAccumulatorPresets,
+  updateAccumulatorPreset,
+  type AccumulatorPreset,
+  type AccumulatorPresetPayload,
+  type UpdateAccumulatorPresetPayload,
+  presetDisplayName,
+} from "./api/accumulatorPresetsApi";
+import AccumulatorPresetsTable from "./AccumulatorPresetsTable";
+import PresetFormDialog from "./PresetFormDialog";
+
+const PAGE_SIZE = 10;
+
+const AccumulatorPresetsPage = () => {
+  const { data: userInfo } = useUserInfo();
+  const showActionsColumn = shouldShowCmsActionsColumn(userInfo?.platform_role);
+  const [search, setSearch] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [debouncedSearch] = useDebounce(search, 500);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingPreset, setEditingPreset] = useState<AccumulatorPreset | null>(
+    null,
+  );
+  const [deleteTarget, setDeleteTarget] = useState<AccumulatorPreset | null>(
+    null,
+  );
+
+  const queryClient = useQueryClient();
+
+  const {
+    data: presetsData,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["cms-accumulator-presets", currentPage, debouncedSearch],
+    queryFn: () =>
+      fetchAccumulatorPresets(currentPage, PAGE_SIZE, debouncedSearch),
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  const invalidatePresets = () => {
+    queryClient.invalidateQueries({ queryKey: ["cms-accumulator-presets"] });
+  };
+
+  const createMutation = useMutation({
+    mutationFn: createAccumulatorPreset,
+    onSuccess: () => {
+      toast.success("Preset created successfully");
+      setFormOpen(false);
+      invalidatePresets();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: UpdateAccumulatorPresetPayload;
+    }) => updateAccumulatorPreset(id, payload),
+    onSuccess: () => {
+      toast.success("Preset updated successfully");
+      setFormOpen(false);
+      setEditingPreset(null);
+      invalidatePresets();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteAccumulatorPreset,
+    onSuccess: () => {
+      toast.success("Preset deleted successfully");
+      setDeleteTarget(null);
+      invalidatePresets();
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const handleOpenCreate = () => {
+    setEditingPreset(null);
+    setFormOpen(true);
+  };
+
+  const handleOpenEdit = (preset: AccumulatorPreset) => {
+    setEditingPreset(preset);
+    setFormOpen(true);
+  };
+
+  const handleFormSubmit = (
+    payload: AccumulatorPresetPayload | UpdateAccumulatorPresetPayload,
+  ) => {
+    if (editingPreset) {
+      updateMutation.mutate({ id: editingPreset.id, payload });
+    } else {
+      createMutation.mutate(payload as AccumulatorPresetPayload);
+    }
+  };
+
+  const totalPages = presetsData
+    ? Math.ceil(presetsData.total / PAGE_SIZE)
+    : 1;
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <div className="flex flex-col border h-[calc(100vh-40px)] overflow-auto bg-[#F5F5F5] dark:bg-[#181818] my-4 rounded-l-2xl font-dynamic">
+      <div className="mb-4 px-4 pt-10 flex items-center justify-between">
+        <div className="flex items-center space-x-2">
+          <div className="border w-fit px-2 bg-white dark:bg-input/30 rounded-md border-gray-200 dark:border-[#313132] flex items-center">
+            <IoMdSearch className="w-4 h-4" />
+            <Pecha.Input
+              placeholder="Search presets..."
+              className="rounded-md border-none dark:bg-transparent px-4 shadow-none py-2"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                if (currentPage !== 1) setCurrentPage(1);
+              }}
+            />
+          </div>
+          {showActionsColumn ? (
+            <Button
+              variant="outline"
+              className="bg-gray-100 hover:bg-gray-200"
+              onClick={handleOpenCreate}
+            >
+              <IoMdAdd /> Add Preset
+            </Button>
+          ) : null}
+        </div>
+        <AuthButton />
+      </div>
+
+      <div className="border-b w-full border-dashed border-gray-300 dark:border-input" />
+
+      <div className="px-4 pt-4 h-full flex flex-col items-center justify-between flex-1 min-h-0">
+        {error ? (
+          <p className="text-sm text-red-500 py-8">
+            Failed to load presets. {getApiErrorMessage(error)}
+          </p>
+        ) : presetsData?.accumulators.length === 0 && !isLoading ? (
+          <div className="flex flex-col h-full items-center justify-center">
+            <p className="text-base text-muted-foreground">No presets found</p>
+            {showActionsColumn ? (
+              <Button
+                variant="outline"
+                className="mt-2"
+                onClick={handleOpenCreate}
+              >
+                <IoMdAdd /> Add Preset
+              </Button>
+            ) : null}
+          </div>
+        ) : (
+          <>
+            <div className="w-full flex-1 overflow-auto">
+              <AccumulatorPresetsTable
+                presets={presetsData?.accumulators ?? []}
+                isLoading={isLoading}
+                showActionsColumn={showActionsColumn}
+                onEdit={handleOpenEdit}
+                onDelete={setDeleteTarget}
+              />
+            </div>
+            {totalPages > 1 ? (
+              <div className="py-4">
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={totalPages}
+                  onPageChange={setCurrentPage}
+                />
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+
+      {showActionsColumn ? (
+        <PresetFormDialog
+          open={formOpen}
+          onOpenChange={(open) => {
+            setFormOpen(open);
+            if (!open) setEditingPreset(null);
+          }}
+          preset={editingPreset}
+          isSubmitting={isSubmitting}
+          onSubmit={handleFormSubmit}
+        />
+      ) : null}
+
+      <Pecha.AlertDialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <Pecha.AlertDialogContent>
+          <Pecha.AlertDialogHeader>
+            <Pecha.AlertDialogTitle>Delete preset?</Pecha.AlertDialogTitle>
+            <Pecha.AlertDialogDescription>
+              This will soft-delete{" "}
+              <strong>
+                {deleteTarget ? presetDisplayName(deleteTarget) : ""}
+              </strong>
+              . It will no longer appear in public preset lists.
+            </Pecha.AlertDialogDescription>
+          </Pecha.AlertDialogHeader>
+          <Pecha.AlertDialogFooter>
+            <Pecha.AlertDialogCancel>Cancel</Pecha.AlertDialogCancel>
+            <Pecha.AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              onClick={() => {
+                if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+              }}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? "Deleting…" : "Delete"}
+            </Pecha.AlertDialogAction>
+          </Pecha.AlertDialogFooter>
+        </Pecha.AlertDialogContent>
+      </Pecha.AlertDialog>
+    </div>
+  );
+};
+
+export default AccumulatorPresetsPage;

--- a/src/components/routes/accumulator-presets/AccumulatorPresetsTable.tsx
+++ b/src/components/routes/accumulator-presets/AccumulatorPresetsTable.tsx
@@ -1,0 +1,112 @@
+import { Pecha } from "@/components/ui/shadimport";
+import { IoMdCreate, IoMdTrash } from "react-icons/io";
+import {
+  type AccumulatorPreset,
+  presetDisplayName,
+} from "./api/accumulatorPresetsApi";
+
+interface AccumulatorPresetsTableProps {
+  presets: AccumulatorPreset[];
+  isLoading?: boolean;
+  showActionsColumn?: boolean;
+  onEdit: (preset: AccumulatorPreset) => void;
+  onDelete: (preset: AccumulatorPreset) => void;
+}
+
+const AccumulatorPresetsTable = ({
+  presets,
+  isLoading,
+  showActionsColumn = true,
+  onEdit,
+  onDelete,
+}: AccumulatorPresetsTableProps) => {
+  if (isLoading) {
+    return (
+      <p className="text-sm text-muted-foreground py-8 text-center">
+        Loading presets...
+      </p>
+    );
+  }
+
+  return (
+    <div className="w-full overflow-x-auto">
+      <Pecha.Table>
+        <Pecha.TableHeader>
+          <Pecha.TableRow>
+            <Pecha.TableHead>Name</Pecha.TableHead>
+            <Pecha.TableHead>Mantra</Pecha.TableHead>
+            <Pecha.TableHead>Text ID</Pecha.TableHead>
+            <Pecha.TableHead className="w-28">Target</Pecha.TableHead>
+            {showActionsColumn ? (
+              <Pecha.TableHead className="w-28 text-right">
+                Actions
+              </Pecha.TableHead>
+            ) : null}
+          </Pecha.TableRow>
+        </Pecha.TableHeader>
+        <Pecha.TableBody>
+          {presets.map((preset) => (
+            <Pecha.TableRow key={preset.id}>
+              <Pecha.TableCell>
+                <div className="flex flex-col gap-1">
+                  <span className="font-medium">
+                    {presetDisplayName(preset)}
+                  </span>
+                  {preset.metadata?.length > 0 ? (
+                    <div className="flex gap-1 flex-wrap">
+                      {preset.metadata.map((meta) => (
+                        <span
+                          key={`${preset.id}-${meta.language}`}
+                          className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400"
+                        >
+                          {meta.language}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </Pecha.TableCell>
+              <Pecha.TableCell className="max-w-[220px] truncate text-sm text-muted-foreground">
+                {preset.mantra?.title?.trim() ||
+                  preset.mantra?.mantra?.trim() ||
+                  "—"}
+              </Pecha.TableCell>
+              <Pecha.TableCell className="max-w-[180px] truncate font-mono text-xs text-muted-foreground">
+                {preset.text_id || "—"}
+              </Pecha.TableCell>
+              <Pecha.TableCell>
+                {preset.target_count != null
+                  ? preset.target_count.toLocaleString()
+                  : "—"}
+              </Pecha.TableCell>
+              {showActionsColumn ? (
+                <Pecha.TableCell>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onEdit(preset)}
+                      className="p-2 rounded-md border hover:bg-muted/50 transition-colors"
+                      aria-label={`Edit ${presetDisplayName(preset)}`}
+                    >
+                      <IoMdCreate className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(preset)}
+                      className="p-2 rounded-md border text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+                      aria-label={`Delete ${presetDisplayName(preset)}`}
+                    >
+                      <IoMdTrash className="w-4 h-4" />
+                    </button>
+                  </div>
+                </Pecha.TableCell>
+              ) : null}
+            </Pecha.TableRow>
+          ))}
+        </Pecha.TableBody>
+      </Pecha.Table>
+    </div>
+  );
+};
+
+export default AccumulatorPresetsTable;

--- a/src/components/routes/accumulator-presets/PresetFormDialog.tsx
+++ b/src/components/routes/accumulator-presets/PresetFormDialog.tsx
@@ -1,0 +1,432 @@
+import { useEffect, useState } from "react";
+import { IoMdAdd, IoMdClose } from "react-icons/io";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Pecha } from "@/components/ui/shadimport";
+import { Textarea } from "@/components/ui/atoms/textarea";
+import { Button } from "@/components/ui/atoms/button";
+import { useLanguages } from "@/hooks/useLanguages";
+import { normalizeLanguageCode } from "@/lib/languageCodes";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+import type { LanguageCode } from "@/schema/SeriesSchema";
+import type { FkOption } from "@/components/routes/groups/components/FkMultiSearchSelector";
+import EventLinkPicker from "@/components/routes/groups/components/events/EventLinkPicker";
+import {
+  type AccumulatorPreset,
+  type AccumulatorPresetPayload,
+  type UpdateAccumulatorPresetPayload,
+  presetDisplayName,
+} from "./api/accumulatorPresetsApi";
+import { createMantra, searchMantrasForPicker } from "./api/mantrasApi";
+import { searchTextsForPicker } from "./api/textPickerApi";
+
+interface PresetFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  preset: AccumulatorPreset | null;
+  isSubmitting: boolean;
+  onSubmit: (
+    payload: AccumulatorPresetPayload | UpdateAccumulatorPresetPayload,
+  ) => void;
+}
+
+interface LanguageData {
+  name: string;
+  description: string;
+}
+
+const PresetFormDialog = ({
+  open,
+  onOpenChange,
+  preset,
+  isSubmitting,
+  onSubmit,
+}: PresetFormDialogProps) => {
+  const isEdit = !!preset;
+  const { languageOptions, getLanguageLabel } = useLanguages();
+  const [activeLanguages, setActiveLanguages] = useState<LanguageCode[]>([
+    "EN",
+  ]);
+  const [languageData, setLanguageData] = useState<
+    Record<string, LanguageData>
+  >({
+    EN: { name: "", description: "" },
+  });
+  const [targetCount, setTargetCount] = useState("");
+  const [textOption, setTextOption] = useState<FkOption | null>(null);
+  const [mantraOption, setMantraOption] = useState<FkOption | null>(null);
+  const [showCreateMantra, setShowCreateMantra] = useState(false);
+  const [newMantraLanguage, setNewMantraLanguage] =
+    useState<LanguageCode>("EN");
+  const [newMantraTitle, setNewMantraTitle] = useState("");
+  const [newMantraText, setNewMantraText] = useState("");
+  const [newMantraPronunciation, setNewMantraPronunciation] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (preset?.metadata && preset.metadata.length > 0) {
+      const langs: LanguageCode[] = [];
+      const data: Record<string, LanguageData> = {};
+      preset.metadata.forEach((meta) => {
+        const lang = normalizeLanguageCode(String(meta.language ?? ""));
+        if (!lang) return;
+        langs.push(lang);
+        data[lang] = {
+          name: meta.name,
+          description: meta.description || "",
+        };
+      });
+      setActiveLanguages(langs.length > 0 ? langs : ["EN"]);
+      setLanguageData(
+        Object.keys(data).length > 0
+          ? data
+          : { EN: { name: "", description: "" } },
+      );
+    } else {
+      setActiveLanguages(["EN"]);
+      setLanguageData({ EN: { name: "", description: "" } });
+    }
+
+    setTargetCount(
+      preset?.target_count != null ? String(preset.target_count) : "",
+    );
+    setTextOption(
+      preset?.text_id
+        ? { id: preset.text_id, title: preset.text_id }
+        : null,
+    );
+    setMantraOption(
+      preset?.mantra
+        ? {
+            id: preset.mantra.id,
+            title:
+              preset.mantra.title?.trim() ||
+              preset.mantra.mantra?.trim() ||
+              preset.mantra.id,
+            image_url: preset.mantra.mala_image_url ?? undefined,
+          }
+        : null,
+    );
+    setShowCreateMantra(false);
+    setNewMantraLanguage("EN");
+    setNewMantraTitle("");
+    setNewMantraText("");
+    setNewMantraPronunciation("");
+  }, [open, preset]);
+
+  const createMantraMutation = useMutation({
+    mutationFn: createMantra,
+    onSuccess: (created) => {
+      const meta = created.metadata?.[0];
+      setMantraOption({
+        id: created.id,
+        title:
+          meta?.title?.trim() ||
+          meta?.mantra?.trim() ||
+          created.id,
+        image_url: created.mala_image_url ?? undefined,
+      });
+      setShowCreateMantra(false);
+      setNewMantraTitle("");
+      setNewMantraText("");
+      setNewMantraPronunciation("");
+      toast.success("Mantra created");
+    },
+    onError: (err) => toast.error(getApiErrorMessage(err)),
+  });
+
+  const availableLanguages = languageOptions.filter(
+    (lang) => !activeLanguages.includes(lang.value),
+  );
+
+  const addLanguage = (langCode: LanguageCode) => {
+    setActiveLanguages([...activeLanguages, langCode]);
+    setLanguageData((prev) => ({
+      ...prev,
+      [langCode]: prev[langCode] ?? { name: "", description: "" },
+    }));
+  };
+
+  const removeLanguage = (langCode: LanguageCode) => {
+    if (activeLanguages.length === 1) {
+      toast.error("At least one language is required");
+      return;
+    }
+    setActiveLanguages(activeLanguages.filter((l) => l !== langCode));
+  };
+
+  const updateLanguageField = (
+    lang: LanguageCode,
+    field: keyof LanguageData,
+    value: string,
+  ) => {
+    setLanguageData((prev) => ({
+      ...prev,
+      [lang]: { ...prev[lang], [field]: value },
+    }));
+  };
+
+  const handleCreateMantra = () => {
+    if (!newMantraText.trim()) {
+      toast.error("Mantra text is required");
+      return;
+    }
+    createMantraMutation.mutate({
+      metadata: [
+        {
+          language: newMantraLanguage,
+          mantra: newMantraText.trim(),
+          title: newMantraTitle.trim() || null,
+          pronunciation: newMantraPronunciation.trim() || null,
+        },
+      ],
+    });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const metadata = activeLanguages
+      .map((lang) => ({
+        language: lang,
+        name: (languageData[lang]?.name ?? "").trim(),
+        description: (languageData[lang]?.description ?? "").trim() || null,
+      }))
+      .filter((entry) => entry.name.length > 0);
+
+    if (metadata.length === 0) {
+      toast.error("At least one language name is required");
+      return;
+    }
+
+    const parsedTarget = targetCount.trim()
+      ? Number(targetCount.trim())
+      : null;
+    if (
+      targetCount.trim() &&
+      (!Number.isFinite(parsedTarget) || (parsedTarget ?? 0) < 1)
+    ) {
+      toast.error("Target count must be a positive number");
+      return;
+    }
+
+    const payload: AccumulatorPresetPayload = {
+      metadata,
+      target_count: parsedTarget,
+      text_id: textOption?.id ?? null,
+      mantra_id: mantraOption?.id ?? null,
+    };
+    onSubmit(payload);
+  };
+
+  return (
+    <Pecha.Dialog open={open} onOpenChange={onOpenChange}>
+      <Pecha.DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <Pecha.DialogHeader>
+          <Pecha.DialogTitle>
+            {isEdit
+              ? `Edit preset — ${presetDisplayName(preset)}`
+              : "Create accumulator preset"}
+          </Pecha.DialogTitle>
+          <Pecha.DialogDescription>
+            Link an optional text and mantra. At least one language name is
+            required.
+          </Pecha.DialogDescription>
+        </Pecha.DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-6 pt-2">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-bold">Names</p>
+              {availableLanguages.length > 0 ? (
+                <Pecha.Select
+                  onValueChange={(v) => addLanguage(v as LanguageCode)}
+                >
+                  <Pecha.SelectTrigger className="w-[160px] h-9">
+                    <Pecha.SelectValue placeholder="Add language" />
+                  </Pecha.SelectTrigger>
+                  <Pecha.SelectContent>
+                    {availableLanguages.map((lang) => (
+                      <Pecha.SelectItem key={lang.value} value={lang.value}>
+                        <span className="flex items-center gap-1">
+                          <IoMdAdd className="w-3 h-3" />
+                          {lang.label}
+                        </span>
+                      </Pecha.SelectItem>
+                    ))}
+                  </Pecha.SelectContent>
+                </Pecha.Select>
+              ) : null}
+            </div>
+
+            {activeLanguages.map((lang) => (
+              <div
+                key={lang}
+                className="space-y-2 rounded-md border p-3 bg-white dark:bg-[#262626]"
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    {getLanguageLabel(lang)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeLanguage(lang)}
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label={`Remove ${lang}`}
+                  >
+                    <IoMdClose className="w-4 h-4" />
+                  </button>
+                </div>
+                <Pecha.Input
+                  placeholder="Name"
+                  className="h-12 bg-white dark:bg-[#262626]"
+                  value={languageData[lang]?.name ?? ""}
+                  onChange={(e) =>
+                    updateLanguageField(lang, "name", e.target.value)
+                  }
+                />
+                <Textarea
+                  placeholder="Description (optional)"
+                  className="min-h-[72px] bg-white dark:bg-[#262626]"
+                  value={languageData[lang]?.description ?? ""}
+                  onChange={(e) =>
+                    updateLanguageField(lang, "description", e.target.value)
+                  }
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <p className="text-sm font-bold">Target count</p>
+            <Pecha.Input
+              type="number"
+              min={1}
+              placeholder="e.g. 100000"
+              className="h-12 bg-white dark:bg-[#262626]"
+              value={targetCount}
+              onChange={(e) => setTargetCount(e.target.value)}
+            />
+          </div>
+
+          <EventLinkPicker
+            label="Linked text (optional)"
+            value={textOption}
+            onChange={setTextOption}
+            searchFn={searchTextsForPicker}
+            queryKeyPrefix="preset-text-picker"
+            searchPlaceholder="Search texts by title…"
+            disabled={isSubmitting}
+          />
+
+          <div className="space-y-3">
+            <EventLinkPicker
+              label="Linked mantra (optional)"
+              value={mantraOption}
+              onChange={setMantraOption}
+              searchFn={searchMantrasForPicker}
+              queryKeyPrefix="preset-mantra-picker"
+              searchPlaceholder="Search mantras…"
+              disabled={isSubmitting || createMantraMutation.isPending}
+            />
+
+            {!showCreateMantra ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() => setShowCreateMantra(true)}
+                disabled={isSubmitting}
+              >
+                <IoMdAdd className="w-4 h-4" />
+                Create new mantra
+              </Button>
+            ) : (
+              <div className="space-y-3 rounded-md border p-3 bg-muted/30">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-bold">New mantra</p>
+                  <button
+                    type="button"
+                    onClick={() => setShowCreateMantra(false)}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <IoMdClose className="w-4 h-4" />
+                  </button>
+                </div>
+                <Pecha.Select
+                  value={newMantraLanguage}
+                  onValueChange={(v) => setNewMantraLanguage(v as LanguageCode)}
+                >
+                  <Pecha.SelectTrigger className="h-12">
+                    <Pecha.SelectValue />
+                  </Pecha.SelectTrigger>
+                  <Pecha.SelectContent>
+                    {languageOptions.map((lang) => (
+                      <Pecha.SelectItem key={lang.value} value={lang.value}>
+                        {lang.label}
+                      </Pecha.SelectItem>
+                    ))}
+                  </Pecha.SelectContent>
+                </Pecha.Select>
+                <Pecha.Input
+                  placeholder="Title (optional)"
+                  className="h-12 bg-white dark:bg-[#262626]"
+                  value={newMantraTitle}
+                  onChange={(e) => setNewMantraTitle(e.target.value)}
+                />
+                <Textarea
+                  placeholder="Mantra text"
+                  className="min-h-[72px] bg-white dark:bg-[#262626]"
+                  value={newMantraText}
+                  onChange={(e) => setNewMantraText(e.target.value)}
+                />
+                <Pecha.Input
+                  placeholder="Pronunciation (optional)"
+                  className="h-12 bg-white dark:bg-[#262626]"
+                  value={newMantraPronunciation}
+                  onChange={(e) => setNewMantraPronunciation(e.target.value)}
+                />
+                <Button
+                  type="button"
+                  className="w-full bg-[#A51C21] text-white hover:bg-[#A51C21]/90"
+                  onClick={handleCreateMantra}
+                  disabled={createMantraMutation.isPending}
+                >
+                  {createMantraMutation.isPending
+                    ? "Creating…"
+                    : "Create mantra"}
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90"
+              disabled={isSubmitting || createMantraMutation.isPending}
+            >
+              {isSubmitting
+                ? isEdit
+                  ? "Saving…"
+                  : "Creating…"
+                : isEdit
+                  ? "Save changes"
+                  : "Create preset"}
+            </Button>
+          </div>
+        </form>
+      </Pecha.DialogContent>
+    </Pecha.Dialog>
+  );
+};
+
+export default PresetFormDialog;

--- a/src/components/routes/accumulator-presets/PresetFormDialog.tsx
+++ b/src/components/routes/accumulator-presets/PresetFormDialog.tsx
@@ -219,6 +219,10 @@ const PresetFormDialog = ({
     onSubmit(payload);
   };
 
+  const idleLabel = isEdit ? "Save changes" : "Create preset";
+  const pendingLabel = isEdit ? "Saving…" : "Creating…";
+  const submitLabel = isSubmitting ? pendingLabel : idleLabel;
+
   return (
     <Pecha.Dialog open={open} onOpenChange={onOpenChange}>
       <Pecha.DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
@@ -414,13 +418,7 @@ const PresetFormDialog = ({
               className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90"
               disabled={isSubmitting || createMantraMutation.isPending}
             >
-              {isSubmitting
-                ? isEdit
-                  ? "Saving…"
-                  : "Creating…"
-                : isEdit
-                  ? "Save changes"
-                  : "Create preset"}
+              {submitLabel}
             </Button>
           </div>
         </form>

--- a/src/components/routes/accumulator-presets/PresetFormDialog.tsx
+++ b/src/components/routes/accumulator-presets/PresetFormDialog.tsx
@@ -228,10 +228,10 @@ const PresetFormDialog = ({
               ? `Edit preset — ${presetDisplayName(preset)}`
               : "Create accumulator preset"}
           </Pecha.DialogTitle>
-          <Pecha.DialogDescription>
+          <p className="text-sm text-muted-foreground">
             Link an optional text and mantra. At least one language name is
             required.
-          </Pecha.DialogDescription>
+          </p>
         </Pecha.DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-6 pt-2">

--- a/src/components/routes/accumulator-presets/PresetFormDialog.tsx
+++ b/src/components/routes/accumulator-presets/PresetFormDialog.tsx
@@ -92,9 +92,7 @@ const PresetFormDialog = ({
       preset?.target_count != null ? String(preset.target_count) : "",
     );
     setTextOption(
-      preset?.text_id
-        ? { id: preset.text_id, title: preset.text_id }
-        : null,
+      preset?.text_id ? { id: preset.text_id, title: preset.text_id } : null,
     );
     setMantraOption(
       preset?.mantra
@@ -121,10 +119,7 @@ const PresetFormDialog = ({
       const meta = created.metadata?.[0];
       setMantraOption({
         id: created.id,
-        title:
-          meta?.title?.trim() ||
-          meta?.mantra?.trim() ||
-          created.id,
+        title: meta?.title?.trim() || meta?.mantra?.trim() || created.id,
         image_url: created.mala_image_url ?? undefined,
       });
       setShowCreateMantra(false);
@@ -199,9 +194,7 @@ const PresetFormDialog = ({
       return;
     }
 
-    const parsedTarget = targetCount.trim()
-      ? Number(targetCount.trim())
-      : null;
+    const parsedTarget = targetCount.trim() ? Number(targetCount.trim()) : null;
     if (
       targetCount.trim() &&
       (!Number.isFinite(parsedTarget) || (parsedTarget ?? 0) < 1)

--- a/src/components/routes/accumulator-presets/api/accumulatorPresetsApi.ts
+++ b/src/components/routes/accumulator-presets/api/accumulatorPresetsApi.ts
@@ -1,0 +1,139 @@
+import axiosInstance from "@/config/axios-config";
+import type { LanguageCode } from "@/schema/SeriesSchema";
+
+export interface AccumulatorMetadataDTO {
+  language: string;
+  name: string;
+  description?: string | null;
+}
+
+export interface PresetMantraDTO {
+  id: string;
+  mantra: string;
+  title?: string | null;
+  pronunciation?: string | null;
+  audio_url?: string | null;
+  mala_image_id?: string | null;
+  mala_image_url?: string | null;
+}
+
+export interface AccumulatorPreset {
+  id: string;
+  group_id: string | null;
+  type: string;
+  target_count: number | null;
+  current_count: number;
+  text_id: string | null;
+  mantra: PresetMantraDTO | null;
+  mala_image_id: string | null;
+  mala_image_url: string | null;
+  metadata: AccumulatorMetadataDTO[];
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface AccumulatorPresetsListResponse {
+  accumulators: AccumulatorPreset[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export interface AccumulatorMetadataInput {
+  language: LanguageCode;
+  name: string;
+  description?: string | null;
+}
+
+export interface AccumulatorPresetPayload {
+  target_count?: number | null;
+  text_id?: string | null;
+  mantra_id?: string | null;
+  mala_image_id?: string | null;
+  metadata: AccumulatorMetadataInput[];
+}
+
+export interface UpdateAccumulatorPresetPayload {
+  target_count?: number | null;
+  text_id?: string | null;
+  mantra_id?: string | null;
+  mala_image_id?: string | null;
+  metadata?: AccumulatorMetadataInput[];
+}
+
+const getAuthHeaders = () => ({
+  Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`,
+});
+
+export const fetchAccumulatorPresets = async (
+  page: number,
+  limit: number,
+  search: string,
+): Promise<AccumulatorPresetsListResponse> => {
+  const skip = (page - 1) * limit;
+  const { data } = await axiosInstance.get<AccumulatorPresetsListResponse>(
+    `/api/v1/cms/accumulators/presets`,
+    {
+      headers: getAuthHeaders(),
+      params: {
+        skip,
+        limit,
+        ...(search && { search }),
+      },
+    },
+  );
+  return data;
+};
+
+export const fetchAccumulatorPreset = async (
+  presetId: string,
+): Promise<AccumulatorPreset> => {
+  const { data } = await axiosInstance.get<AccumulatorPreset>(
+    `/api/v1/cms/accumulators/presets/${presetId}`,
+    { headers: getAuthHeaders() },
+  );
+  return data;
+};
+
+export const createAccumulatorPreset = async (
+  payload: AccumulatorPresetPayload,
+): Promise<AccumulatorPreset> => {
+  const { data } = await axiosInstance.post<AccumulatorPreset>(
+    `/api/v1/cms/accumulators/presets`,
+    payload,
+    { headers: getAuthHeaders() },
+  );
+  return data;
+};
+
+export const updateAccumulatorPreset = async (
+  presetId: string,
+  payload: UpdateAccumulatorPresetPayload,
+): Promise<AccumulatorPreset> => {
+  const { data } = await axiosInstance.put<AccumulatorPreset>(
+    `/api/v1/cms/accumulators/presets/${presetId}`,
+    payload,
+    { headers: getAuthHeaders() },
+  );
+  return data;
+};
+
+export const deleteAccumulatorPreset = async (
+  presetId: string,
+): Promise<void> => {
+  await axiosInstance.delete(`/api/v1/cms/accumulators/presets/${presetId}`, {
+    headers: getAuthHeaders(),
+  });
+};
+
+export function presetDisplayName(preset: AccumulatorPreset): string {
+  const metaName = preset.metadata?.[0]?.name?.trim();
+  if (metaName) return metaName;
+  const mantraTitle = preset.mantra?.title?.trim();
+  if (mantraTitle) return mantraTitle;
+  const mantraText = preset.mantra?.mantra?.trim();
+  if (mantraText) {
+    return mantraText.length > 60 ? `${mantraText.slice(0, 57)}…` : mantraText;
+  }
+  return "Untitled preset";
+}

--- a/src/components/routes/accumulator-presets/api/mantrasApi.ts
+++ b/src/components/routes/accumulator-presets/api/mantrasApi.ts
@@ -1,0 +1,109 @@
+import axiosInstance from "@/config/axios-config";
+import type { LanguageCode } from "@/schema/SeriesSchema";
+import type { FkOption } from "@/components/routes/groups/components/FkMultiSearchSelector";
+
+export interface MantraMetadataDTO {
+  id: string;
+  mantra: string;
+  title?: string | null;
+  pronunciation?: string | null;
+  language: string;
+}
+
+export interface MantraDTO {
+  id: string;
+  audio_url?: string | null;
+  mala_image_id?: string | null;
+  mala_image_url?: string | null;
+  metadata: MantraMetadataDTO[];
+}
+
+export interface MantraResponse {
+  mantras: MantraDTO[];
+}
+
+export interface MantraMetadataInput {
+  language: LanguageCode;
+  mantra: string;
+  title?: string | null;
+  pronunciation?: string | null;
+}
+
+export interface CreateMantraPayload {
+  audio_url?: string | null;
+  mala_image_id?: string | null;
+  metadata: MantraMetadataInput[];
+}
+
+const getAuthHeaders = () => ({
+  Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`,
+});
+
+export function mantraDisplayLabel(mantra: MantraDTO): string {
+  const meta = mantra.metadata?.[0];
+  const title = meta?.title?.trim();
+  if (title) return title;
+  const text = meta?.mantra?.trim();
+  if (text) return text.length > 60 ? `${text.slice(0, 57)}…` : text;
+  return "Untitled mantra";
+}
+
+export const fetchMantras = async (
+  language?: string,
+): Promise<MantraResponse> => {
+  const { data } = await axiosInstance.get<MantraResponse>(`/api/v1/mantra`, {
+    params: language ? { language } : undefined,
+  });
+  return data;
+};
+
+export const createMantra = async (
+  payload: CreateMantraPayload,
+): Promise<MantraDTO> => {
+  const { data } = await axiosInstance.post<MantraDTO>(
+    `/api/v1/cms/mantras`,
+    payload,
+    { headers: getAuthHeaders() },
+  );
+  return data;
+};
+
+/** Client-side filtered mantra search for EventLinkPicker. */
+export async function searchMantrasForPicker(params: {
+  search?: string;
+  skip?: number;
+  limit?: number;
+}): Promise<{
+  items: FkOption[];
+  skip: number;
+  limit: number;
+  total: number;
+}> {
+  const skip = params.skip ?? 0;
+  const limit = params.limit ?? 20;
+  const { mantras } = await fetchMantras();
+  const term = params.search?.trim().toLowerCase() ?? "";
+
+  const filtered = mantras.filter((mantra) => {
+    if (!term) return true;
+    return mantra.metadata.some((meta) => {
+      const haystack = [meta.title, meta.mantra, meta.pronunciation]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(term);
+    });
+  });
+
+  const page = filtered.slice(skip, skip + limit);
+  return {
+    items: page.map((mantra) => ({
+      id: mantra.id,
+      title: mantraDisplayLabel(mantra),
+      image_url: mantra.mala_image_url ?? undefined,
+    })),
+    skip,
+    limit,
+    total: filtered.length,
+  };
+}

--- a/src/components/routes/accumulator-presets/api/textPickerApi.ts
+++ b/src/components/routes/accumulator-presets/api/textPickerApi.ts
@@ -1,0 +1,59 @@
+import { searchTitles } from "@/components/api/searchApi";
+import type { FkOption } from "@/components/routes/groups/components/FkMultiSearchSelector";
+
+type TitleSearchItem = {
+  id: string;
+  title?: string | null;
+};
+
+type TitleSearchResponse = {
+  sources?: TitleSearchItem[];
+  texts?: TitleSearchItem[];
+  results?: TitleSearchItem[];
+  total?: number;
+};
+
+function extractItems(data: TitleSearchResponse | TitleSearchItem[]): TitleSearchItem[] {
+  if (Array.isArray(data)) return data;
+  return data.sources ?? data.texts ?? data.results ?? [];
+}
+
+/** Wrap title-search into EventLinkPicker / FkOption shape. */
+export async function searchTextsForPicker(params: {
+  search?: string;
+  skip?: number;
+  limit?: number;
+}): Promise<{
+  items: FkOption[];
+  skip: number;
+  limit: number;
+  total: number;
+}> {
+  const skip = params.skip ?? 0;
+  const limit = params.limit ?? 20;
+  const title = params.search?.trim() ?? "";
+
+  if (!title) {
+    return { items: [], skip, limit, total: 0 };
+  }
+
+  const data = (await searchTitles({
+    title,
+    limit,
+    offset: skip,
+  })) as TitleSearchResponse | TitleSearchItem[];
+
+  const items = extractItems(data)
+    .filter((item) => item?.id)
+    .map((item) => ({
+      id: item.id,
+      title: item.title?.trim() || item.id,
+    }));
+
+  const total =
+    !Array.isArray(data) && typeof data.total === "number"
+      ? data.total
+      : skip + items.length + (items.length === limit ? 1 : 0);
+
+  return { items, skip, limit, total };
+}

--- a/src/components/routes/accumulator-presets/api/textPickerApi.ts
+++ b/src/components/routes/accumulator-presets/api/textPickerApi.ts
@@ -13,7 +13,9 @@ type TitleSearchResponse = {
   total?: number;
 };
 
-function extractItems(data: TitleSearchResponse | TitleSearchItem[]): TitleSearchItem[] {
+function extractItems(
+  data: TitleSearchResponse | TitleSearchItem[],
+): TitleSearchItem[] {
   if (Array.isArray(data)) return data;
   return data.sources ?? data.texts ?? data.results ?? [];
 }

--- a/src/components/routes/dashboard/DashboardContentTable.tsx
+++ b/src/components/routes/dashboard/DashboardContentTable.tsx
@@ -9,10 +9,7 @@ import type {
   DashboardLanguageCode,
   DashboardTableRow,
 } from "./dashboardTable";
-import {
-  DASHBOARD_TABLE_ICON_BTN,
-  isMockDashboardId,
-} from "./dashboardTable";
+import { DASHBOARD_TABLE_ICON_BTN, isMockDashboardId } from "./dashboardTable";
 import { ROUTES } from "@/routes/paths";
 import { FeaturedStar, languageChip, statusChip } from "./dashboardTableUi";
 import type { PlatformRole } from "@/lib/platformAccess";
@@ -72,7 +69,7 @@ export function DashboardContentTable({
         row.kind === "plan" ? ROUTES.plan(row.id) : ROUTES.series(row.id);
       const canOpenTitle =
         row.kind === "series" || canAccessPlanRoutes(platformRole);
-   
+
       const canToggleFeatured =
         row.kind === "series" ||
         (row.kind === "plan" && !isMockDashboardId(row.id));
@@ -143,7 +140,7 @@ export function DashboardContentTable({
           <Pecha.TableCell className="text-sm text-center">
             {row.enrolled}
           </Pecha.TableCell>
-        
+
           <Pecha.TableCell className="text-center">
             {canToggleFeatured && canFeature && !platformReadOnly ? (
               <Pecha.Button
@@ -224,7 +221,7 @@ export function DashboardContentTable({
           <Pecha.TableHead className="w-[100px] font-bold text-center">
             {t("studio.dashboard.plan_used")}
           </Pecha.TableHead>
-         
+
           <Pecha.TableHead className="w-[72px] font-bold text-center">
             Featured
           </Pecha.TableHead>

--- a/src/components/routes/groups/api/accumulatorPresetSearchApi.ts
+++ b/src/components/routes/groups/api/accumulatorPresetSearchApi.ts
@@ -54,6 +54,7 @@ export async function searchAccumulatorPresets(params: {
       params: {
         skip,
         limit,
+        show_recitations: true,
         ...(params.search?.trim() && { search: params.search.trim() }),
       },
     },

--- a/src/components/routes/groups/components/GroupAccumulatorsPanel.tsx
+++ b/src/components/routes/groups/components/GroupAccumulatorsPanel.tsx
@@ -245,7 +245,10 @@ const GroupAccumulatorsPanel = ({
         preset: {
           id: created.id,
           title: presetDisplayName(created),
-          image_url: created.mala_image_url ?? created.mantra?.mala_image_url ?? undefined,
+          image_url:
+            created.mala_image_url ??
+            created.mantra?.mala_image_url ??
+            undefined,
         },
       }));
       setCreatePresetOpen(false);

--- a/src/components/routes/groups/components/GroupAccumulatorsPanel.tsx
+++ b/src/components/routes/groups/components/GroupAccumulatorsPanel.tsx
@@ -10,7 +10,7 @@ import ImageContentData from "@/components/ui/molecules/modals/image-upload/Imag
 import { uploadImageToS3 } from "@/components/routes/task/api/taskApi";
 import { getApiErrorMessage } from "@/lib/apiErrors";
 import { canChangeContentStatus } from "@/lib/contentPermissions";
-import { isReviewer } from "@/lib/platformAccess";
+import { isReviewer, shouldShowCmsActionsColumn } from "@/lib/platformAccess";
 import { fromBackendISO, toBackendISO } from "@/lib/utils";
 import { useUserInfo } from "@/hooks/useUserInfo";
 import type { AuthorGroupMemberRole } from "../api/groupsApi";
@@ -23,6 +23,13 @@ import {
   updateGroupAccumulator,
   type GroupAccumulatorDTO,
 } from "../api/groupAccumulatorsApi";
+import {
+  createAccumulatorPreset,
+  presetDisplayName,
+  type AccumulatorPresetPayload,
+  type UpdateAccumulatorPresetPayload,
+} from "@/components/routes/accumulator-presets/api/accumulatorPresetsApi";
+import PresetFormDialog from "@/components/routes/accumulator-presets/PresetFormDialog";
 import GroupImageField from "./GroupImageField";
 import { GroupSectionHeader } from "./GroupSection";
 import type { FkOption } from "./FkMultiSearchSelector";
@@ -85,6 +92,7 @@ const GroupAccumulatorsPanel = ({
   const queryClient = useQueryClient();
   const { data: userInfo } = useUserInfo();
   const platformReadOnly = isReviewer(userInfo?.platform_role);
+  const canCreatePresets = shouldShowCmsActionsColumn(userInfo?.platform_role);
   const canCreate =
     !platformReadOnly && groupRole != null && groupRole !== "VIEWER";
   const canManage =
@@ -103,6 +111,7 @@ const GroupAccumulatorsPanel = ({
   const [presetQuery, setPresetQuery] = useState("");
   const [presetResults, setPresetResults] = useState<FkOption[]>([]);
   const [presetLoading, setPresetLoading] = useState(false);
+  const [createPresetOpen, setCreatePresetOpen] = useState(false);
   const [startDateOpen, setStartDateOpen] = useState(false);
   const [endDateOpen, setEndDateOpen] = useState(false);
 
@@ -226,6 +235,34 @@ const GroupAccumulatorsPanel = ({
     },
     onError: toastOnError,
   });
+
+  const createPresetMutation = useMutation({
+    mutationFn: createAccumulatorPreset,
+    onSuccess: (created) => {
+      toast.success("Preset created");
+      setForm((prev) => ({
+        ...prev,
+        preset: {
+          id: created.id,
+          title: presetDisplayName(created),
+          image_url: created.mala_image_url ?? created.mantra?.mala_image_url ?? undefined,
+        },
+      }));
+      setCreatePresetOpen(false);
+      setPresetSearchOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["cms-accumulator-presets"] });
+      searchAccumulatorPresets({ limit: 20 }).then((result) => {
+        setPresetResults(result.items);
+      });
+    },
+    onError: toastOnError,
+  });
+
+  const handleCreatePresetSubmit = (
+    payload: AccumulatorPresetPayload | UpdateAccumulatorPresetPayload,
+  ) => {
+    createPresetMutation.mutate(payload as AccumulatorPresetPayload);
+  };
 
   const handleImageUpload = async (file: File) => {
     setImageUploading(true);
@@ -541,6 +578,18 @@ const GroupAccumulatorsPanel = ({
                         >
                           None
                         </Pecha.CommandItem>
+                        {canCreatePresets ? (
+                          <Pecha.CommandItem
+                            value="__create_preset__"
+                            onSelect={() => {
+                              setPresetSearchOpen(false);
+                              setCreatePresetOpen(true);
+                            }}
+                          >
+                            <IoMdAdd className="mr-2 h-4 w-4" />
+                            Create new preset…
+                          </Pecha.CommandItem>
+                        ) : null}
                         {presetLoading ? (
                           <Pecha.CommandItem disabled value="__loading__">
                             Searching…
@@ -565,7 +614,8 @@ const GroupAccumulatorsPanel = ({
                 </Pecha.PopoverContent>
               </Pecha.Popover>
               <p className="text-xs text-muted-foreground">
-                Optional link to a public mantra preset users count with.
+                Optional link to a public preset (mantra and/or text) users
+                count with.
               </p>
             </div>
 
@@ -604,6 +654,16 @@ const GroupAccumulatorsPanel = ({
           />
         </Pecha.DialogContent>
       </Pecha.Dialog>
+
+      {canCreatePresets ? (
+        <PresetFormDialog
+          open={createPresetOpen}
+          onOpenChange={setCreatePresetOpen}
+          preset={null}
+          isSubmitting={createPresetMutation.isPending}
+          onSubmit={handleCreatePresetSubmit}
+        />
+      ) : null}
 
       <Pecha.AlertDialog
         open={deleteTarget != null}

--- a/src/components/ui/molecules/auth-button/AuthButton.tsx
+++ b/src/components/ui/molecules/auth-button/AuthButton.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { IoChevronBack, IoNotificationsOutline, IoPersonOutline } from "react-icons/io5";
+import {
+  IoChevronBack,
+  IoNotificationsOutline,
+  IoPersonOutline,
+} from "react-icons/io5";
 import { useAuth } from "@/config/auth-context";
 import { NO_PROFILE_IMAGE } from "@/lib/constant";
 import { ROUTES } from "@/routes/paths";

--- a/src/components/ui/molecules/nav-bar/Navbar.tsx
+++ b/src/components/ui/molecules/nav-bar/Navbar.tsx
@@ -1,7 +1,7 @@
 import pechaIcon from "../../../../assets/icon/pecha_icon.png";
 import { Link, useLocation } from "react-router-dom";
 import { ModeToggle } from "../mode-toggle/modetoggle";
-import { IoAnalytics, IoPricetags, IoPeople } from "react-icons/io5";
+import { IoAnalytics, IoPricetags, IoPeople, IoPulse } from "react-icons/io5";
 import { MdDashboard, MdAdminPanelSettings, MdPublicOff } from "react-icons/md";
 import { ROUTES } from "@/routes/paths";
 import { LanguageToggle } from "../language-toggle/languageToggle";
@@ -35,6 +35,12 @@ const navItems = [
     label: "Tags",
     path: ROUTES.tags,
     tooltip: "Manage tags",
+  },
+  {
+    icon: <IoPulse className="w-4 h-4" />,
+    label: "Presets",
+    path: ROUTES.accumulatorPresets,
+    tooltip: "Manage accumulator presets",
   },
   {
     icon: <IoPeople className="w-4 h-4" />,

--- a/src/components/ui/molecules/notification-bell/NotificationsPanel.tsx
+++ b/src/components/ui/molecules/notification-bell/NotificationsPanel.tsx
@@ -183,9 +183,7 @@ export function NotificationsPanel({
                       size="sm"
                       className="bg-[#A51C21] text-white hover:bg-[#A51C21]/90 h-7 text-xs"
                       disabled={invitePending}
-                      onClick={() =>
-                        handleInviteAction(notification, "accept")
-                      }
+                      onClick={() => handleInviteAction(notification, "accept")}
                     >
                       {inviteActionMutation.isPending &&
                       inviteActionMutation.variables?.action === "accept"
@@ -198,9 +196,7 @@ export function NotificationsPanel({
                       variant="outline"
                       className="h-7 text-xs"
                       disabled={invitePending}
-                      onClick={() =>
-                        handleInviteAction(notification, "reject")
-                      }
+                      onClick={() => handleInviteAction(notification, "reject")}
                     >
                       {inviteActionMutation.isPending &&
                       inviteActionMutation.variables?.action === "reject"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,6 +49,7 @@ import GroupChantDetailPage from "./components/routes/groups/GroupChantDetailPag
 import GroupFormPage from "./components/routes/groups/GroupFormPage.tsx";
 import AdminAuthorsPage from "./components/routes/admin-authors/AdminAuthorsPage.tsx";
 import ChinaRestrictionsPage from "./components/routes/china-restrictions/ChinaRestrictionsPage.tsx";
+import AccumulatorPresetsPage from "./components/routes/accumulator-presets/AccumulatorPresetsPage.tsx";
 import { UserbackProvider } from "./config/userback-context.tsx";
 import { Navigate } from "react-router-dom";
 import { ROUTES } from "./routes/paths.ts";
@@ -208,6 +209,14 @@ const router = createBrowserRouter([
         element: (
           <ProtectedRoute>
             <VerseOfDay />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: ROUTES.accumulatorPresets,
+        element: (
+          <ProtectedRoute>
+            <AccumulatorPresetsPage />
           </ProtectedRoute>
         ),
       },

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -41,6 +41,7 @@ export const ROUTES = {
   groupSeriesNew: (groupId: string) => `/groups/${groupId}/series/new`,
   adminAuthors: "/admin/authors",
   adminChinaRestrictions: "/admin/china-restrictions",
+  accumulatorPresets: "/accumulator-presets",
 } as const;
 
 export const AUTH_ROUTE_PATHS: readonly string[] = [


### PR DESCRIPTION
- Introduced AccumulatorPresetsPage and integrated it into the router.
- Updated accumulatorPresetSearchApi to include 'show_recitations' parameter.
- Enhanced GroupAccumulatorsPanel to support creating new presets with a dialog.
- Added a new navigation item for managing accumulator presets.
- Defined a new route for accumulator presets in paths.ts.