### PR TITLE
Update GroupInvitesAdminSection to clarify invitee requirements

### DIFF
--- a/src/components/auth/login/Login.tsx
+++ b/src/components/auth/login/Login.tsx
@@ -2,7 +2,11 @@ import { Button } from "@/components/ui/atoms/button";
 import { Input } from "@/components/ui/atoms/input";
 import { Label } from "@/components/ui/atoms/label";
 import ContainerLayout from "@/components/ui/atoms/studio-card";
-import { IoCallOutline, IoLockClosedOutline, IoMailOutline } from "react-icons/io5";
+import {
+  IoCallOutline,
+  IoLockClosedOutline,
+  IoMailOutline,
+} from "react-icons/io5";
 import { FcGoogle } from "react-icons/fc";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";

--- a/src/components/routes/groups/components/GroupInvitesAdminSection.tsx
+++ b/src/components/routes/groups/components/GroupInvitesAdminSection.tsx
@@ -229,8 +229,10 @@ const GroupInvitesAdminSection = ({
           </Pecha.DialogHeader>
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
-              The invitee must already be a registered author. They will receive
-              an email and an in-app notification (valid for about 30 minutes).
+              The invitee does not need a Studio account yet — they&apos;ll get an
+              email invite either way. If they&apos;re already registered they&apos;ll
+              also get an in-app notification now; otherwise it appears once
+              they sign up and verify their email (valid for about 30 minutes).
               Authors who previously left can be invited again if they are not
               currently members and have no pending invite for this email.
             </p>

--- a/src/components/routes/groups/components/GroupInvitesAdminSection.tsx
+++ b/src/components/routes/groups/components/GroupInvitesAdminSection.tsx
@@ -229,12 +229,13 @@ const GroupInvitesAdminSection = ({
           </Pecha.DialogHeader>
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
-              The invitee does not need a Studio account yet — they&apos;ll get an
-              email invite either way. If they&apos;re already registered they&apos;ll
-              also get an in-app notification now; otherwise it appears once
-              they sign up and verify their email (valid for about 30 minutes).
-              Authors who previously left can be invited again if they are not
-              currently members and have no pending invite for this email.
+              The invitee does not need a Studio account yet — they&apos;ll get
+              an email invite either way. If they&apos;re already registered
+              they&apos;ll also get an in-app notification now; otherwise it
+              appears once they sign up and verify their email (valid for about
+              30 minutes). Authors who previously left can be invited again if
+              they are not currently members and have no pending invite for this
+              email.
             </p>
             <div className="space-y-2">
               <label className="text-sm font-medium">Email</label>

--- a/src/components/routes/traditions/TraditionFormDialog.tsx
+++ b/src/components/routes/traditions/TraditionFormDialog.tsx
@@ -116,7 +116,10 @@ const TraditionFormDialog = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    const normalizedCode = code.trim().toLowerCase().replace(/[\s-]+/g, "_");
+    const normalizedCode = code
+      .trim()
+      .toLowerCase()
+      .replace(/[\s-]+/g, "_");
     if (!/^[a-z][a-z0-9_]{1,62}$/.test(normalizedCode)) {
       toast.error(
         "Code must start with a letter and use lowercase letters, numbers, or underscores",

--- a/src/components/routes/traditions/TraditionsPage.tsx
+++ b/src/components/routes/traditions/TraditionsPage.tsx
@@ -63,13 +63,8 @@ const TraditionsPage = () => {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({
-      id,
-      payload,
-    }: {
-      id: string;
-      payload: TraditionPayload;
-    }) => updateTradition(id, payload),
+    mutationFn: ({ id, payload }: { id: string; payload: TraditionPayload }) =>
+      updateTradition(id, payload),
     onSuccess: () => {
       toast.success("Tradition updated successfully");
       setFormOpen(false);
@@ -174,7 +169,9 @@ const TraditionsPage = () => {
         )}
       </div>
 
-      <Activity mode={traditionsData?.traditions?.length ? "visible" : "hidden"}>
+      <Activity
+        mode={traditionsData?.traditions?.length ? "visible" : "hidden"}
+      >
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}

--- a/src/components/ui/molecules/modals/day-create/DayCreateDialog.test.tsx
+++ b/src/components/ui/molecules/modals/day-create/DayCreateDialog.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+import DayCreateDialog from "./DayCreateDialog";
+
+const mockSearchPlans = vi.fn();
+const mockFetchPlanDetails = vi.fn();
+
+vi.mock("@/components/routes/task/api/planApi", () => ({
+  searchCmsPlans: (...args: unknown[]) => mockSearchPlans(...args),
+  fetchPlanDetails: (...args: unknown[]) => mockFetchPlanDetails(...args),
+}));
+
+function renderDialog(onSubmit = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DayCreateDialog onSubmit={onSubmit} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DayCreateDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchPlans.mockResolvedValue({
+      plans: [
+        {
+          id: "source-plan-id",
+          title: "Source Plan",
+          language: "EN",
+          total_days: 2,
+        },
+      ],
+      skip: 0,
+      limit: 10,
+      total: 1,
+    });
+  });
+
+  it("does not crash when the selected template plan has no days", async () => {
+    mockFetchPlanDetails.mockResolvedValue({
+      id: "source-plan-id",
+      title: "Source Plan",
+      days: [],
+    });
+
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Add New Day"));
+    fireEvent.focus(screen.getByPlaceholderText("Search plans…"));
+    fireEvent.change(screen.getByPlaceholderText("Search plans…"), {
+      target: { value: "Source" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Source Plan")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Source Plan"));
+
+    await waitFor(() => {
+      expect(screen.getByText("No days in this plan")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a day picker when the template plan has days", async () => {
+    mockFetchPlanDetails.mockResolvedValue({
+      id: "source-plan-id",
+      title: "Source Plan",
+      days: [{ id: "source-day-id", day_number: 1, tasks: [] }],
+    });
+
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Add New Day"));
+    fireEvent.focus(screen.getByPlaceholderText("Search plans…"));
+    fireEvent.change(screen.getByPlaceholderText("Search plans…"), {
+      target: { value: "Source" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Source Plan")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Source Plan"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+      expect(screen.getByText("Select a day…")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/molecules/modals/day-create/DayCreateDialog.tsx
+++ b/src/components/ui/molecules/modals/day-create/DayCreateDialog.tsx
@@ -333,10 +333,7 @@ const DayCreateDialog = ({
                       </Pecha.SelectTrigger>
                       <Pecha.SelectContent>
                         {templateDays.map((day) => (
-                          <Pecha.SelectItem
-                            key={day.id}
-                            value={String(day.id)}
-                          >
+                          <Pecha.SelectItem key={day.id} value={String(day.id)}>
                             Day {day.day_number}
                           </Pecha.SelectItem>
                         ))}

--- a/src/components/ui/molecules/modals/day-create/DayCreateDialog.tsx
+++ b/src/components/ui/molecules/modals/day-create/DayCreateDialog.tsx
@@ -68,13 +68,16 @@ const DayCreateDialog = ({
     },
   );
 
-  const { data: templatePlanData, isFetching: isTemplatePlanFetching } =
-    useQuery({
-      queryKey: ["day-create-template-plan", templatePlanId],
-      queryFn: () => fetchPlanDetails(templatePlanId!),
-      enabled: !!templatePlanId && open,
-      refetchOnWindowFocus: false,
-    });
+  const {
+    data: templatePlanData,
+    isFetching: isTemplatePlanFetching,
+    isError: isTemplatePlanError,
+  } = useQuery({
+    queryKey: ["day-create-template-plan", templatePlanId],
+    queryFn: () => fetchPlanDetails(templatePlanId!),
+    enabled: !!templatePlanId && open,
+    refetchOnWindowFocus: false,
+  });
 
   const planOptions = planSearchData?.pages.flatMap((page) => page.plans) ?? [];
   const templateDays: Array<{ id: string; day_number: number }> =
@@ -106,7 +109,8 @@ const DayCreateDialog = ({
     resetForm();
   };
 
-  const formatPlanLanguage = (language: string) => {
+  const formatPlanLanguage = (language: string | undefined | null) => {
+    if (!language) return "";
     const code = normalizeLanguageCode(language);
     return code ? getNativeLanguageLabel(code) : language;
   };
@@ -311,29 +315,31 @@ const DayCreateDialog = ({
                       <FiLoader className="w-4 h-4 animate-spin" />
                       Loading days…
                     </div>
+                  ) : isTemplatePlanError ? (
+                    <p className="text-sm text-destructive py-1">
+                      Could not load days for this plan
+                    </p>
+                  ) : templateDays.length === 0 ? (
+                    <p className="text-sm text-muted-foreground py-1">
+                      No days in this plan
+                    </p>
                   ) : (
                     <Pecha.Select
-                      value={sourceDayId ?? ""}
-                      onValueChange={(v) =>
-                        setSourceDayId(v === "" ? undefined : v)
-                      }
+                      value={sourceDayId}
+                      onValueChange={setSourceDayId}
                     >
                       <Pecha.SelectTrigger className="bg-background">
                         <Pecha.SelectValue placeholder="Select a day…" />
                       </Pecha.SelectTrigger>
                       <Pecha.SelectContent>
-                        {templateDays.map((day) => {
-                          return (
-                            <Pecha.SelectItem key={day.id} value={day.id}>
-                              Day {day.day_number}
-                            </Pecha.SelectItem>
-                          );
-                        })}
-                        {templateDays.length === 0 && (
-                          <Pecha.SelectItem value="" disabled>
-                            No days in this plan
+                        {templateDays.map((day) => (
+                          <Pecha.SelectItem
+                            key={day.id}
+                            value={String(day.id)}
+                          >
+                            Day {day.day_number}
                           </Pecha.SelectItem>
-                        )}
+                        ))}
                       </Pecha.SelectContent>
                     </Pecha.Select>
                   )}

--- a/src/components/ui/molecules/nav-bar/Navbar.test.tsx
+++ b/src/components/ui/molecules/nav-bar/Navbar.test.tsx
@@ -25,7 +25,9 @@ describe("Navbar", () => {
 
     renderNavbar();
 
-    expect(screen.getByRole("link", { name: /manage author groups/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /manage author groups/i }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: /go to dashboard/i }),
     ).not.toBeInTheDocument();
@@ -54,10 +56,9 @@ describe("Navbar", () => {
 
     renderNavbar();
 
-    expect(screen.getByRole("link", { name: /pecha studio logo/i })).toHaveAttribute(
-      "href",
-      "/groups",
-    );
+    expect(
+      screen.getByRole("link", { name: /pecha studio logo/i }),
+    ).toHaveAttribute("href", "/groups");
   });
 
   it("shows the full nav for a SUPER_ADMIN account", () => {
@@ -68,11 +69,21 @@ describe("Navbar", () => {
 
     renderNavbar();
 
-    expect(screen.getByRole("link", { name: /go to dashboard/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /view analytics/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /manage tags/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /manage author groups/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /author administration/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /go to dashboard/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /view analytics/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /manage tags/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /manage author groups/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /author administration/i }),
+    ).toBeInTheDocument();
   });
 
   it("shows the full nav for a REVIEWER account", () => {
@@ -83,8 +94,12 @@ describe("Navbar", () => {
 
     renderNavbar();
 
-    expect(screen.getByRole("link", { name: /go to dashboard/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /manage author groups/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /go to dashboard/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /manage author groups/i }),
+    ).toBeInTheDocument();
   });
 
   it("does not restrict the nav while user info is still loading", () => {
@@ -95,6 +110,8 @@ describe("Navbar", () => {
 
     renderNavbar();
 
-    expect(screen.getByRole("link", { name: /go to dashboard/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /go to dashboard/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/ui/molecules/nav-bar/Navbar.tsx
+++ b/src/components/ui/molecules/nav-bar/Navbar.tsx
@@ -1,7 +1,13 @@
 import pechaIcon from "../../../../assets/icon/pecha_icon.png";
 import { Link, useLocation } from "react-router-dom";
 import { ModeToggle } from "../mode-toggle/modetoggle";
-import { IoAnalytics, IoPricetags, IoPeople, IoPulse, IoBook} from "react-icons/io5";
+import {
+  IoAnalytics,
+  IoPricetags,
+  IoPeople,
+  IoPulse,
+  IoBook,
+} from "react-icons/io5";
 import {
   MdAudioFile,
   MdDashboard,


### PR DESCRIPTION
- Revised text to indicate that invitees do not need a Studio account to receive email invites.
- Added details about in-app notifications for registered users and the timing of notifications upon signup and email verification.