### PR TITLE
Enhance plan day creation with series overlap handling

### DIFF
--- a/src/components/routes/task/api/planApi.ts
+++ b/src/components/routes/task/api/planApi.ts
@@ -57,6 +57,7 @@ export const fetchPlanDays = async (plan_id: string) => {
 export interface CreateDaysRequest {
   number_of_days?: number;
   source_day_id?: string;
+  cascade?: boolean;
 }
 
 export interface DayDTO {

--- a/src/components/routes/task/components/sidebar-component/SideBar.tsx
+++ b/src/components/routes/task/components/sidebar-component/SideBar.tsx
@@ -1,4 +1,4 @@
-import { useState, Activity } from "react";
+import { useEffect, useState, Activity } from "react";
 import { IoCalendarClearOutline } from "react-icons/io5";
 import { MdExpandMore } from "react-icons/md";
 import { BsThreeDots } from "react-icons/bs";
@@ -46,10 +46,18 @@ const SideBar = ({
   const [selectedDayIds, setSelectedDayIds] = useState<Set<string>>(new Set());
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
   const [seriesOverlapPrompt, setSeriesOverlapPrompt] = useState<{
+    planId: string;
     request: { number_of_days?: number; source_day_id?: string };
     overflowDays: number;
     nextPlanStartDate: string;
   } | null>(null);
+
+  // Discard any pending overlap confirmation if the author navigates to a
+  // different plan before confirming — it must never fire against a plan
+  // other than the one whose overlap was actually approved.
+  useEffect(() => {
+    setSeriesOverlapPrompt(null);
+  }, [planId]);
 
   const { data: currentPlan, isLoading } = useQuery({
     queryKey: ["planDetails", planId],
@@ -130,8 +138,9 @@ const SideBar = ({
       onSuccess: onDaysCreated,
       onError: (error: any) => {
         const detail = error?.response?.data?.detail;
-        if (detail?.code === PLAN_DAYS_OVERLAP_NEXT_PLAN_CODE) {
+        if (detail?.code === PLAN_DAYS_OVERLAP_NEXT_PLAN_CODE && planId) {
           setSeriesOverlapPrompt({
+            planId,
             request: req,
             overflowDays: detail.overflow_days,
             nextPlanStartDate: detail.next_plan_start_date,
@@ -143,8 +152,12 @@ const SideBar = ({
 
   const handleConfirmSeriesShift = () => {
     if (!seriesOverlapPrompt) return;
-    const { request } = seriesOverlapPrompt;
+    const { planId: promptPlanId, request } = seriesOverlapPrompt;
     setSeriesOverlapPrompt(null);
+    // The mutation binds to the plan currently in the route; if that plan
+    // changed since the prompt was raised, drop the stale request instead of
+    // shifting the wrong plan's series.
+    if (promptPlanId !== planId) return;
     createNewDay.mutate(
       { ...request, cascade: true },
       { onSuccess: onDaysCreated },

--- a/src/components/routes/task/components/sidebar-component/SideBar.tsx
+++ b/src/components/routes/task/components/sidebar-component/SideBar.tsx
@@ -114,9 +114,7 @@ const SideBar = ({
     setShowBulkDeleteConfirm(false);
   };
 
-  const onDaysCreated = (
-    newDays?: { day_number: number }[] | null,
-  ) => {
+  const onDaysCreated = (newDays?: { day_number: number }[] | null) => {
     if (newDays && newDays.length > 0) {
       onDaySelect(newDays[0].day_number);
       setExpandedDay(newDays[0].day_number);
@@ -526,8 +524,7 @@ const SideBar = ({
               which starts on {seriesOverlapPrompt?.nextPlanStartDate}. Shift
               that plan (and any plans after it) forward by{" "}
               {seriesOverlapPrompt?.overflowDays} day
-              {seriesOverlapPrompt?.overflowDays === 1 ? "" : "s"} to make
-              room?
+              {seriesOverlapPrompt?.overflowDays === 1 ? "" : "s"} to make room?
             </Pecha.AlertDialogDescription>
           </Pecha.AlertDialogHeader>
           <Pecha.AlertDialogFooter>

--- a/src/components/routes/task/components/sidebar-component/SideBar.tsx
+++ b/src/components/routes/task/components/sidebar-component/SideBar.tsx
@@ -15,7 +15,10 @@ import { SortableList, SortableItem } from "@/components/ui/atoms/sortable";
 import { PiDotsSixVertical } from "react-icons/pi";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchPlanDetails } from "../../api/planApi";
-import { usePlanMutations } from "../../hooks/usePlanMutations";
+import {
+  usePlanMutations,
+  PLAN_DAYS_OVERLAP_NEXT_PLAN_CODE,
+} from "../../hooks/usePlanMutations";
 import { useTaskReorder } from "../../hooks/useTaskReorder";
 import { useDayReorder } from "../../hooks/useDayReorder";
 
@@ -42,6 +45,11 @@ const SideBar = ({
   const [isSelectMode, setIsSelectMode] = useState(false);
   const [selectedDayIds, setSelectedDayIds] = useState<Set<string>>(new Set());
   const [showBulkDeleteConfirm, setShowBulkDeleteConfirm] = useState(false);
+  const [seriesOverlapPrompt, setSeriesOverlapPrompt] = useState<{
+    request: { number_of_days?: number; source_day_id?: string };
+    overflowDays: number;
+    nextPlanStartDate: string;
+  } | null>(null);
 
   const { data: currentPlan, isLoading } = useQuery({
     queryKey: ["planDetails", planId],
@@ -106,19 +114,43 @@ const SideBar = ({
     setShowBulkDeleteConfirm(false);
   };
 
+  const onDaysCreated = (
+    newDays?: { day_number: number }[] | null,
+  ) => {
+    if (newDays && newDays.length > 0) {
+      onDaySelect(newDays[0].day_number);
+      setExpandedDay(newDays[0].day_number);
+    }
+    queryClient.invalidateQueries({ queryKey: ["planDetails", planId] });
+  };
+
   const handleCreateDays = (req: {
     number_of_days?: number;
     source_day_id?: string;
   }) => {
     createNewDay.mutate(req, {
-      onSuccess: (newDays) => {
-        if (newDays && newDays.length > 0) {
-          onDaySelect(newDays[0].day_number);
-          setExpandedDay(newDays[0].day_number);
+      onSuccess: onDaysCreated,
+      onError: (error: any) => {
+        const detail = error?.response?.data?.detail;
+        if (detail?.code === PLAN_DAYS_OVERLAP_NEXT_PLAN_CODE) {
+          setSeriesOverlapPrompt({
+            request: req,
+            overflowDays: detail.overflow_days,
+            nextPlanStartDate: detail.next_plan_start_date,
+          });
         }
-        queryClient.invalidateQueries({ queryKey: ["planDetails", planId] });
       },
     });
+  };
+
+  const handleConfirmSeriesShift = () => {
+    if (!seriesOverlapPrompt) return;
+    const { request } = seriesOverlapPrompt;
+    setSeriesOverlapPrompt(null);
+    createNewDay.mutate(
+      { ...request, cascade: true },
+      { onSuccess: onDaysCreated },
+    );
   };
 
   const canEnterSelectMode =
@@ -474,6 +506,38 @@ const SideBar = ({
               onClick={handleBulkDelete}
             >
               Delete
+            </Pecha.AlertDialogAction>
+          </Pecha.AlertDialogFooter>
+        </Pecha.AlertDialogContent>
+      </Pecha.AlertDialog>
+
+      {/* Series overlap: offer to shift the rest of the series forward */}
+      <Pecha.AlertDialog
+        open={!!seriesOverlapPrompt}
+        onOpenChange={(open) => !open && setSeriesOverlapPrompt(null)}
+      >
+        <Pecha.AlertDialogContent>
+          <Pecha.AlertDialogHeader>
+            <Pecha.AlertDialogTitle>
+              Shift the rest of the series?
+            </Pecha.AlertDialogTitle>
+            <Pecha.AlertDialogDescription>
+              Adding these days would push past the next plan in this series,
+              which starts on {seriesOverlapPrompt?.nextPlanStartDate}. Shift
+              that plan (and any plans after it) forward by{" "}
+              {seriesOverlapPrompt?.overflowDays} day
+              {seriesOverlapPrompt?.overflowDays === 1 ? "" : "s"} to make
+              room?
+            </Pecha.AlertDialogDescription>
+          </Pecha.AlertDialogHeader>
+          <Pecha.AlertDialogFooter>
+            <Pecha.AlertDialogCancel
+              onClick={() => setSeriesOverlapPrompt(null)}
+            >
+              Cancel
+            </Pecha.AlertDialogCancel>
+            <Pecha.AlertDialogAction onClick={handleConfirmSeriesShift}>
+              Shift schedule &amp; add days
             </Pecha.AlertDialogAction>
           </Pecha.AlertDialogFooter>
         </Pecha.AlertDialogContent>

--- a/src/components/routes/task/hooks/usePlanMutations.ts
+++ b/src/components/routes/task/hooks/usePlanMutations.ts
@@ -6,6 +6,9 @@ import {
   deleteTask,
   type CreateDaysRequest,
 } from "../api/planApi";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+
+export const PLAN_DAYS_OVERLAP_NEXT_PLAN_CODE = "PLAN_DAYS_OVERLAP_NEXT_PLAN";
 
 export const usePlanMutations = (plan_id: string | undefined) => {
   const queryClient = useQueryClient();
@@ -38,7 +41,7 @@ export const usePlanMutations = (plan_id: string | undefined) => {
     },
     onError: (error: any) => {
       toast.error("Failed to delete day(s)", {
-        description: error.response?.data?.detail || "Something went wrong",
+        description: getApiErrorMessage(error),
       });
     },
   });
@@ -46,8 +49,15 @@ export const usePlanMutations = (plan_id: string | undefined) => {
   const createNewDaysMutation = useMutation({
     mutationFn: (body?: CreateDaysRequest) => createNewDays(plan_id!, body),
     onError: (error: any) => {
+      // The overlap case is handled by the caller, which offers to shift the
+      // rest of the series forward instead of showing a dead-end error.
+      if (
+        error?.response?.data?.detail?.code === PLAN_DAYS_OVERLAP_NEXT_PLAN_CODE
+      ) {
+        return;
+      }
       toast.error("Failed to create days", {
-        description: error.response?.data?.detail || "Something went wrong",
+        description: getApiErrorMessage(error),
       });
     },
   });


### PR DESCRIPTION
- Added a cascade option to the CreateDaysRequest interface to manage overlapping plans.
- Implemented a prompt in the SideBar component to offer users the option to shift subsequent plans when adding new days would cause overlaps.
- Updated error handling in usePlanMutations to manage overlap scenarios without displaying dead-end errors.