### PR TITLE
Refactor CreatePlan and CreateSeries components for improved query ma…

### DIFF
--- a/src/components/routes/create-plan/CreatePlan.tsx
+++ b/src/components/routes/create-plan/CreatePlan.tsx
@@ -35,7 +35,7 @@ import { DIFFICULTY } from "@/lib/constant";
 import { useLanguages } from "@/hooks/useLanguages";
 import { cn, toBackendISO, fromBackendISO, isPastDate } from "@/lib/utils";
 import axiosInstance from "@/config/axios-config";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Pecha } from "@/components/ui/shadimport";
 import ImageContentData from "@/components/ui/molecules/modals/image-upload/ImageContentData";
@@ -100,6 +100,7 @@ const Createplan = () => {
   );
   type PlanFormData = z.infer<typeof planSchema>;
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (isCreateMode && !groupId) {
@@ -281,14 +282,11 @@ const Createplan = () => {
       toast.success("Plan created successfully!", {
         description: "Your plan has been created and is now available.",
       });
+      void queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
       form.reset();
       setSelectedImage(null);
       setImagePreview(null);
-      if (groupId) {
-        navigate(ROUTES.group(groupId));
-      } else {
-        navigate(ROUTES.plan(data.id));
-      }
+      navigate(ROUTES.plan(data.id));
     },
     onError: (error) => {
       toast.error("Failed to create plan", {
@@ -299,10 +297,11 @@ const Createplan = () => {
   const updatePlanMutation = useMutation({
     mutationFn: updatePlan,
     onSuccess: () => {
-      toast.success("Plan updated successfully!", {
-        description: "Your plan has been updated and is now available.",
-      });
-      navigate(ROUTES.dashboard);
+      toast.success("Saved");
+      void queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
+      if (planId) {
+        void queryClient.invalidateQueries({ queryKey: ["plan", planId] });
+      }
     },
     onError: (error) => {
       toast.error("Failed to update plan", {

--- a/src/components/routes/create-series/hooks/useCreateSeriesController.ts
+++ b/src/components/routes/create-series/hooks/useCreateSeriesController.ts
@@ -127,6 +127,17 @@ export const useCreateSeriesController = () => {
     seriesId,
     groupId,
     seriesData,
+    onUpdated: (updated) => {
+      seriesHydratedIdRef.current = updated.id;
+      form.reset(mapSeriesDetailToFormData(updated));
+      const resolvedImageUrl = resolveDashboardItemImageUrl({
+        image_url: updated.image_url,
+        image_key: updated.image_key,
+        image: updated.image,
+      });
+      setImagePreview(resolvedImageUrl || null);
+      setSelectedImage(null);
+    },
   });
 
   const onSubmit = form.handleSubmit((data) => {

--- a/src/components/routes/create-series/hooks/useCreateSeriesController.ts
+++ b/src/components/routes/create-series/hooks/useCreateSeriesController.ts
@@ -127,12 +127,6 @@ export const useCreateSeriesController = () => {
     seriesId,
     groupId,
     seriesData,
-    onCreated: () => {
-      form.reset({ languages: {}, plans: {}, image_url: "" });
-      setSelectedImage(null);
-      setImagePreview(null);
-      setActivePlansLanguage(null);
-    },
   });
 
   const onSubmit = form.handleSubmit((data) => {

--- a/src/components/routes/create-series/hooks/useCreateSeriesController.ts
+++ b/src/components/routes/create-series/hooks/useCreateSeriesController.ts
@@ -134,9 +134,10 @@ export const useCreateSeriesController = () => {
     seriesData,
     onUpdated: (updated) => {
       seriesHydratedIdRef.current = updated.id;
-      // keepDirtyValues preserves any edits made while the request was in
-      // flight, syncing the server-normalized baseline into untouched fields
-      // only, so newer local edits are never silently overwritten.
+      // The onSubmit handler already rebased dirty-tracking onto the
+      // submitted snapshot, so any field still dirty here was edited *after*
+      // submission and is preserved; everything else takes the fresh
+      // server-normalized value and becomes the new clean baseline.
       form.reset(mapSeriesDetailToFormData(updated), {
         keepDirtyValues: true,
       });
@@ -163,6 +164,13 @@ export const useCreateSeriesController = () => {
       file: image.selectedImage,
       preview: image.imagePreview,
     };
+    if (!isNew) {
+      // Rebase the clean baseline onto exactly what's being submitted, so
+      // dirty-tracking during the pending request only flags edits made
+      // *after* this point, letting onUpdated tell those apart from the
+      // fields that were simply part of this save.
+      form.reset(data, { keepValues: true });
+    }
     saveSeriesMutation.mutate({ data, featured });
   });
 

--- a/src/components/routes/create-series/hooks/useCreateSeriesController.ts
+++ b/src/components/routes/create-series/hooks/useCreateSeriesController.ts
@@ -3,7 +3,7 @@ import { useBlocker, useNavigate, useParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { ROUTES } from "@/routes/paths";
 import { sortLanguageCodes } from "@/lib/languageCodes";
-import type { LanguageCode } from "@/schema/SeriesSchema";
+import type { LanguageCode, SeriesFormData } from "@/schema/SeriesSchema";
 import { useGroupContentPermissions } from "@/hooks/useGroupContentPermissions";
 import { canWriteCms } from "@/lib/platformAccess";
 import { useSeriesForm } from "@/components/routes/create-series/hooks/useSeriesForm";
@@ -77,6 +77,7 @@ export const useCreateSeriesController = () => {
     file: File | null;
     preview: string | null;
   }>({ file: null, preview: null });
+  const preSubmitBaselineRef = useRef<SeriesFormData | null>(null);
 
   useEffect(() => {
     if (isNew || !seriesData) return;
@@ -154,6 +155,17 @@ export const useCreateSeriesController = () => {
         setImagePreview(resolvedImageUrl || null);
         setSelectedImage(null);
       }
+      preSubmitBaselineRef.current = null;
+    },
+    onUpdateFailed: () => {
+      // The submit rebase already stamped the in-flight values as "clean"
+      // optimistically; since persistence failed, restore the prior
+      // baseline so those unsaved edits are dirty again, Save re-enables,
+      // and the unsaved-changes navigation guard protects them.
+      if (preSubmitBaselineRef.current) {
+        form.reset(preSubmitBaselineRef.current, { keepValues: true });
+        preSubmitBaselineRef.current = null;
+      }
     },
   });
 
@@ -165,6 +177,10 @@ export const useCreateSeriesController = () => {
       preview: image.imagePreview,
     };
     if (!isNew) {
+      // Snapshot the current baseline so a failed save can restore it.
+      preSubmitBaselineRef.current = structuredClone(
+        form.formState.defaultValues,
+      ) as SeriesFormData;
       // Rebase the clean baseline onto exactly what's being submitted, so
       // dirty-tracking during the pending request only flags edits made
       // *after* this point, letting onUpdated tell those apart from the

--- a/src/components/routes/create-series/hooks/useCreateSeriesController.ts
+++ b/src/components/routes/create-series/hooks/useCreateSeriesController.ts
@@ -78,6 +78,7 @@ export const useCreateSeriesController = () => {
     preview: string | null;
   }>({ file: null, preview: null });
   const preSubmitBaselineRef = useRef<SeriesFormData | null>(null);
+  const submittedSeriesIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (isNew || !seriesData) return;
@@ -114,26 +115,19 @@ export const useCreateSeriesController = () => {
     }
   }, [orderedAddedLanguages, activePlansLanguage]);
 
-  const hasUnsavedChanges =
-    form.formState.isDirty && !form.formState.isSubmitSuccessful;
-
-  const blocker = useBlocker(
-    ({ currentLocation, nextLocation }) =>
-      hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname,
-  );
-
-  useEffect(() => {
-    if (blocker.state === "blocked") {
-      setShowNavigationDialog(true);
-    }
-  }, [blocker.state]);
-
   const saveSeriesMutation = useSaveSeries({
     isNew,
     seriesId,
     groupId,
     seriesData,
     onUpdated: (updated) => {
+      if (submittedSeriesIdRef.current !== seriesId) {
+        // The route has since navigated to a different series; the form
+        // now mounted belongs to that other record, so applying this
+        // response here would silently overwrite it with the wrong
+        // series' content.
+        return;
+      }
       seriesHydratedIdRef.current = updated.id;
       // The onSubmit handler already rebased dirty-tracking onto the
       // submitted snapshot, so any field still dirty here was edited *after*
@@ -158,6 +152,11 @@ export const useCreateSeriesController = () => {
       preSubmitBaselineRef.current = null;
     },
     onUpdateFailed: () => {
+      if (submittedSeriesIdRef.current !== seriesId) {
+        // Same guard as onUpdated: this failure belongs to a series that's
+        // no longer mounted, so there's no local baseline to restore here.
+        return;
+      }
       // The submit rebase already stamped the in-flight values as "clean"
       // optimistically; since persistence failed, restore the prior
       // baseline so those unsaved edits are dirty again, Save re-enables,
@@ -169,6 +168,21 @@ export const useCreateSeriesController = () => {
     },
   });
 
+  const hasUnsavedChanges =
+    (form.formState.isDirty && !form.formState.isSubmitSuccessful) ||
+    (!isNew && saveSeriesMutation.isPending);
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname,
+  );
+
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      setShowNavigationDialog(true);
+    }
+  }, [blocker.state]);
+
   const onSubmit = form.handleSubmit((data) => {
     if (formReadOnly) return;
     const featured = isNew ? false : (seriesData?.featured ?? false);
@@ -177,6 +191,10 @@ export const useCreateSeriesController = () => {
       preview: image.imagePreview,
     };
     if (!isNew) {
+      // Tag this request with the series it was submitted for, so a
+      // response that arrives after the route has moved on to a different
+      // series can be told apart and ignored instead of misapplied.
+      submittedSeriesIdRef.current = seriesId ?? null;
       // Snapshot the current baseline so a failed save can restore it.
       preSubmitBaselineRef.current = structuredClone(
         form.formState.defaultValues,

--- a/src/components/routes/create-series/hooks/useCreateSeriesController.ts
+++ b/src/components/routes/create-series/hooks/useCreateSeriesController.ts
@@ -73,6 +73,11 @@ export const useCreateSeriesController = () => {
     seriesHydratedIdRef.current = null;
   }, [seriesId]);
 
+  const pendingImageSnapshotRef = useRef<{
+    file: File | null;
+    preview: string | null;
+  }>({ file: null, preview: null });
+
   useEffect(() => {
     if (isNew || !seriesData) return;
     if (seriesHydratedIdRef.current === seriesData.id) return;
@@ -129,20 +134,35 @@ export const useCreateSeriesController = () => {
     seriesData,
     onUpdated: (updated) => {
       seriesHydratedIdRef.current = updated.id;
-      form.reset(mapSeriesDetailToFormData(updated));
-      const resolvedImageUrl = resolveDashboardItemImageUrl({
-        image_url: updated.image_url,
-        image_key: updated.image_key,
-        image: updated.image,
+      // keepDirtyValues preserves any edits made while the request was in
+      // flight, syncing the server-normalized baseline into untouched fields
+      // only, so newer local edits are never silently overwritten.
+      form.reset(mapSeriesDetailToFormData(updated), {
+        keepDirtyValues: true,
       });
-      setImagePreview(resolvedImageUrl || null);
-      setSelectedImage(null);
+
+      const imageChangedDuringSave =
+        image.selectedImage !== pendingImageSnapshotRef.current.file ||
+        image.imagePreview !== pendingImageSnapshotRef.current.preview;
+      if (!imageChangedDuringSave) {
+        const resolvedImageUrl = resolveDashboardItemImageUrl({
+          image_url: updated.image_url,
+          image_key: updated.image_key,
+          image: updated.image,
+        });
+        setImagePreview(resolvedImageUrl || null);
+        setSelectedImage(null);
+      }
     },
   });
 
   const onSubmit = form.handleSubmit((data) => {
     if (formReadOnly) return;
     const featured = isNew ? false : (seriesData?.featured ?? false);
+    pendingImageSnapshotRef.current = {
+      file: image.selectedImage,
+      preview: image.imagePreview,
+    };
     saveSeriesMutation.mutate({ data, featured });
   });
 

--- a/src/components/routes/create-series/hooks/useSaveSeries.ts
+++ b/src/components/routes/create-series/hooks/useSaveSeries.ts
@@ -19,7 +19,6 @@ type UseSaveSeriesParams = {
   seriesId?: string;
   groupId?: string;
   seriesData?: SeriesDetailDTO;
-  onCreated: () => void;
 };
 
 export const useSaveSeries = ({
@@ -27,7 +26,6 @@ export const useSaveSeries = ({
   seriesId,
   groupId,
   seriesData,
-  onCreated,
 }: UseSaveSeriesParams) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -49,22 +47,15 @@ export const useSaveSeries = ({
       await putUpdateSeries({ seriesId, body });
       return { id: seriesId };
     },
-    onSuccess: () => {
-      toast.success(
-        isNew ? "Series created successfully!" : "Series updated successfully!",
-      );
+    onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
-      if (seriesId && !isNew) {
-        void queryClient.invalidateQueries({ queryKey: ["series", seriesId] });
-      }
       if (isNew) {
-        onCreated();
-        if (groupId) {
-          navigate(ROUTES.group(groupId));
-          return;
-        }
+        toast.success("Series created successfully!");
+        navigate(ROUTES.series(result.id));
+        return;
       }
-      navigate(ROUTES.dashboard);
+      toast.success("Saved");
+      void queryClient.invalidateQueries({ queryKey: ["series", seriesId] });
     },
     onError: (error: Error) => {
       toast.error(

--- a/src/components/routes/create-series/hooks/useSaveSeries.ts
+++ b/src/components/routes/create-series/hooks/useSaveSeries.ts
@@ -20,6 +20,7 @@ type UseSaveSeriesParams = {
   groupId?: string;
   seriesData?: SeriesDetailDTO;
   onUpdated: (series: SeriesDetailDTO) => void;
+  onUpdateFailed: () => void;
 };
 
 export const useSaveSeries = ({
@@ -28,6 +29,7 @@ export const useSaveSeries = ({
   groupId,
   seriesData,
   onUpdated,
+  onUpdateFailed,
 }: UseSaveSeriesParams) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -65,6 +67,9 @@ export const useSaveSeries = ({
           description: error.message,
         },
       );
+      if (!isNew) {
+        onUpdateFailed();
+      }
     },
   });
 };

--- a/src/components/routes/create-series/hooks/useSaveSeries.ts
+++ b/src/components/routes/create-series/hooks/useSaveSeries.ts
@@ -19,6 +19,7 @@ type UseSaveSeriesParams = {
   seriesId?: string;
   groupId?: string;
   seriesData?: SeriesDetailDTO;
+  onUpdated: (series: SeriesDetailDTO) => void;
 };
 
 export const useSaveSeries = ({
@@ -26,6 +27,7 @@ export const useSaveSeries = ({
   seriesId,
   groupId,
   seriesData,
+  onUpdated,
 }: UseSaveSeriesParams) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -34,8 +36,7 @@ export const useSaveSeries = ({
     mutationFn: async ({ data, featured }: SaveSeriesInput) => {
       if (isNew) {
         const body = buildSeriesCreateBody(data, featured, groupId);
-        const created = await postSeries(body);
-        return { id: String(created.id) };
+        return postSeries(body);
       }
       if (!seriesId || !seriesData) {
         throw new Error("Missing series data for update");
@@ -44,8 +45,7 @@ export const useSaveSeries = ({
         original: mapSeriesDetailToFormData(seriesData),
         originalFeatured: seriesData.featured,
       });
-      await putUpdateSeries({ seriesId, body });
-      return { id: seriesId };
+      return putUpdateSeries({ seriesId, body });
     },
     onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: ["dashboard-items"] });
@@ -55,7 +55,8 @@ export const useSaveSeries = ({
         return;
       }
       toast.success("Saved");
-      void queryClient.invalidateQueries({ queryKey: ["series", seriesId] });
+      queryClient.setQueryData(["series", seriesId], result);
+      onUpdated(result);
     },
     onError: (error: Error) => {
       toast.error(


### PR DESCRIPTION
…nagement

- Added useQueryClient to CreatePlan for better cache invalidation after plan creation and updates.
- Simplified the onSuccess handling in useSaveSeries to streamline navigation and query invalidation.
- Removed redundant onCreated callback in useSaveSeries to enhance clarity and reduce complexity.